### PR TITLE
On Cancel, if there is no authorization_id, assume the order was neve…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- On Cancel, if there is no authorization_id, assume the order was never completed and return successful cancellation
+
 ## [1.1.13] - 2020-05-28
 
 ### Fixed

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -108,13 +108,20 @@
         /// <returns></returns>
         public async Task<CancelPaymentResponse> CancelPayment(CancelPaymentRequest cancelPaymentRequest, string publicKey, string privateKey)
         {
-            CancelPaymentResponse cancelPaymentResponse = null;
+            CancelPaymentResponse cancelPaymentResponse = new CancelPaymentResponse
+            {
+                cancellationId = null,
+                code = null,
+                message = "Empty",
+                paymentId = cancelPaymentRequest.paymentId,
+                requestId = cancelPaymentRequest.requestId
+            };
 
             // Load request from storage for order id
             CreatePaymentRequest paymentRequest = await this._paymentRequestRepository.GetPaymentRequestAsync(cancelPaymentRequest.paymentId);
             if (paymentRequest == null)
             {
-                cancelPaymentResponse.message = "Could not load Payment Request.";
+                cancelPaymentResponse.message = $"Could not load Payment Request for Payment Id {cancelPaymentRequest.paymentId}.";
             }
             else
             {
@@ -142,6 +149,11 @@
                     message = affirmResponse.created ?? affirmResponse.Error.Message,
                     requestId = cancelPaymentRequest.requestId
                 };
+            }
+            else
+            {
+                // Assume that the order was never authorized
+                cancelPaymentResponse.cancellationId = "not_authorized";
             }
 
             return cancelPaymentResponse;


### PR DESCRIPTION
…r completed and return successful cancellation