### PR TITLE
PostCallback order changed and improve logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Change order of postCallBackResponse
+- Update logs for err and info
+
 ## [1.3.0] - 2021-10-21
 
 ### Added

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -188,8 +188,6 @@
 
         public async Task<IActionResult> Inbound(string paymentId, string actiontype)
         {
-            _context.Vtex.Logger.Info($"InboundAsync action = {actiontype}");
-
             string responseCode = string.Empty;
             string responseMessage = string.Empty;
             string responseStatusCode = string.Empty;

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -188,7 +188,7 @@
 
         public async Task<IActionResult> Inbound(string paymentId, string actiontype)
         {
-            Console.WriteLine($"InboundAsync action = {actiontype}");
+            _context.Vtex.Logger.Info($"InboundAsync action = {actiontype}");
 
             string responseCode = string.Empty;
             string responseMessage = string.Empty;

--- a/dotnet/Data/PaymentRequestRepository.cs
+++ b/dotnet/Data/PaymentRequestRepository.cs
@@ -9,6 +9,7 @@
     using Affirm.Services;
     using Microsoft.AspNetCore.Http;
     using Newtonsoft.Json;
+    using Vtex.Api.Context;
 
     /// <summary>
     /// Concrete implementation of <see cref="IPaymentRequestRepository"/> for persisting data to/from vbase.
@@ -28,9 +29,10 @@
         private readonly HttpClient _httpClient;
         private readonly string _applicationName;
         private string AUTHORIZATION_HEADER_NAME;
+        private readonly IIOServiceContext _context;
 
 
-        public PaymentRequestRepository(IVtexEnvironmentVariableProvider environmentVariableProvider, IHttpContextAccessor httpContextAccessor, HttpClient httpClient)
+        public PaymentRequestRepository(IVtexEnvironmentVariableProvider environmentVariableProvider, IHttpContextAccessor httpContextAccessor, HttpClient httpClient, IIOServiceContext context)
         {
             this._environmentVariableProvider = environmentVariableProvider ??
                                                 throw new ArgumentNullException(nameof(environmentVariableProvider));
@@ -43,6 +45,9 @@
 
             this._applicationName =
                 $"{this._environmentVariableProvider.ApplicationVendor}.{this._environmentVariableProvider.ApplicationName}";
+
+            this._context = context ??
+                throw new ArgumentNullException(nameof(context));
 
             AUTHORIZATION_HEADER_NAME = "Authorization";
         }
@@ -238,7 +243,7 @@
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"PostCallbackResponse {callbackUrl} Error: {ex.Message} InnerException: {ex.InnerException} StackTrace: {ex.StackTrace}");
+                _context.Vtex.Logger.Error("PostCallBackResponse", null, $"PostCallbackResponse {callbackUrl} Error: {ex.Message} InnerException: {ex.InnerException} StackTrace: {ex.StackTrace}", ex);
             }
 
             response.EnsureSuccessStatusCode();

--- a/dotnet/Services/AffirmAPI.cs
+++ b/dotnet/Services/AffirmAPI.cs
@@ -310,7 +310,7 @@
                 }
             }
 
-            Console.WriteLine($"Parsed Response = {parsedResponse}");
+            _context.Vtex.Logger.Info($"Parsed Response = {parsedResponse}");
 
             return parsedResponse;
         }

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -368,7 +368,7 @@
                 if (affirmResponse.charge_id != null || affirmResponse.reference_id != null)
                 {
                     string chargeId = affirmResponse.charge_id ?? affirmResponse.reference_id;
-                    Console.WriteLine($"Getting current status for {chargeId}");
+                    _context.Vtex.Logger.Info($"Getting current status for {chargeId}");
                     affirmResponse = await affirmAPI.ReadChargeAsync(publicKey, privateKey, chargeId);
                     if (affirmResponse.status != null && affirmResponse.status == AffirmConstants.SuccessResponseCode)
                     {
@@ -404,8 +404,6 @@
 
             paymentResponse.message = message;
 
-            await this._paymentRequestRepository.PostCallbackResponse(callbackUrl, paymentResponse);
-
             // Save the Affirm id & order number - will need for capture
             CreatePaymentRequest paymentRequest = new CreatePaymentRequest
             {
@@ -419,6 +417,8 @@
                 await this._paymentRequestRepository.SavePaymentRequestAsync(paymentIdentifier, paymentRequest);
                 await this._paymentRequestRepository.SavePaymentResponseAsync(paymentResponse);
             }
+
+            await this._paymentRequestRepository.PostCallbackResponse(callbackUrl, paymentResponse);
 
             return paymentResponse;
         }

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -368,7 +368,6 @@
                 if (affirmResponse.charge_id != null || affirmResponse.reference_id != null)
                 {
                     string chargeId = affirmResponse.charge_id ?? affirmResponse.reference_id;
-                    _context.Vtex.Logger.Info($"Getting current status for {chargeId}");
                     affirmResponse = await affirmAPI.ReadChargeAsync(publicKey, privateKey, chargeId);
                     if (affirmResponse.status != null && affirmResponse.status == AffirmConstants.SuccessResponseCode)
                     {


### PR DESCRIPTION
## Description:
- The current flow for the checkout payments changed, and after a discussion with the payments team we have decided to change the order of the logic in order to get the correct paymentResponse. 
- Payments team discussion ``` the app encountered an error, so it prevented the app from storing the new payment status, and therefore when the next retry request was received, the correct status could not be loaded```

## Changes made:
- The callback url is not being sent until we have the a valid `paymentResponse`