### PR TITLE
[AFFIRM-9] Fix authorization retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Authorization retries will be denied if stored payment status is "undefined", to ensure that users who close the Affirm modal are not redirected to the "order placed" page
+
 ## [1.3.1] - 2021-12-09
 
 ### Fixed
+
 - Change order of postCallBackResponse
 - Update logs for err and info
 
 ## [1.3.0] - 2021-10-21
 
 ### Added
+
 - Save createPaymentResponse
 - Add createSavePaymentResponse Repository
 
@@ -28,13 +34,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.2.1] - 2021-02-04
 
 ### Added
- 
+
 - Logging
 
 ## [1.2.0] - 2021-01-29
 
 ### Added
- 
+
 - Added idempotency key
 
 ## [1.1.22] - 2020-11-11
@@ -52,13 +58,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.20] - 2020-08-28
 
 ### Added
- 
+
 - For Katapult refunds, look up the Discount amount
 
 ## [1.1.19] - 2020-08-25
 
 ### Added
- 
+
 - Added logging
 
 ## [1.1.18] - 2020-08-25
@@ -74,13 +80,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Proxy header
 
 ### Added
- 
+
 - Katapult urls to outbound access
 
 ## [1.1.16] - 2020-06-17
 
- ### Added
- 
+### Added
+
 - Get Katapult funding information
 
 ## [1.1.15] - 2020-06-10
@@ -88,9 +94,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Capture bugfix
- 
- ### Added
- 
+
+### Added
+
 - Adding support for Katapult funding
 
 ## [1.1.14] - 2020-06-02
@@ -152,7 +158,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Support for new `orderId` field in PaymentRequest object
-- Support for payment cancellations triggered through gateway by frontend 
+- Support for payment cancellations triggered through gateway by frontend
 - Use `vtex.affirm-payment` appSettings `isLive` boolean to determine whether transaction is live or sandbox
 
 ## [0.1.0] - 2019-08-06

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -41,8 +41,13 @@
         {
             CreatePaymentResponse paymentResponse = null;
             paymentResponse = await this._paymentRequestRepository.GetPaymentResponseAsync(createPaymentRequest.paymentId);
-            if(paymentResponse != null)
+            if (paymentResponse != null)
             {
+                // If this is a retry, a stored payment with undefined status should be treated as denied
+                if (paymentResponse.status == AffirmConstants.Vtex.Undefined)
+                {
+                    paymentResponse.status = AffirmConstants.Vtex.Denied;
+                }
                 return paymentResponse;
             }
             else
@@ -115,7 +120,7 @@
             //paymentResponse.paymentUrl = $"{siteHostSuffix}{redirectUrl}?g={paymentIdentifier}&k={publicKey}";
 
             await this._paymentRequestRepository.SavePaymentResponseAsync(paymentResponse);
-            
+
             return paymentResponse;
         }
 
@@ -145,8 +150,8 @@
             {
                 //if (cancelPaymentRequest.authorizationId == null)
                 //{
-                    // Get Affirm id from storage
-                    cancelPaymentRequest.authorizationId = paymentRequest.transactionId;
+                // Get Affirm id from storage
+                cancelPaymentRequest.authorizationId = paymentRequest.transactionId;
                 //}
             }
 
@@ -252,7 +257,7 @@
                                 {
                                     capturePaymentResponse.value = affirmResponse.amount == null ? capturePaymentRequest.value : (decimal)affirmResponse.amount / 100m;
                                     KatapultFunding katapultResponse = await affirmAPI.KatapultFundingAsync(vtexSettings.katapultPrivateToken);
-                                    if(katapultResponse != null)
+                                    if (katapultResponse != null)
                                     {
                                         FundingObject fundingObject = katapultResponse.FundingReport.FundingObjects.Where(f => f.OrderId.Equals(paymentRequest.orderId)).FirstOrDefault();
                                         capturePaymentResponse.message = JsonConvert.SerializeObject(fundingObject);
@@ -396,7 +401,7 @@
                 message = affirmResponse.Error.Message;
             }
 
-            if(affirmResponse.fields != null)
+            if (affirmResponse.fields != null)
             {
                 message = $"{message}: {affirmResponse.fields}";
             }

--- a/manifest.json
+++ b/manifest.json
@@ -6,9 +6,7 @@
   "description": "An implementation of Affirm",
   "categories": [],
   "settingsSchema": {},
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "builders": {
     "dotnet": "2.x"
   },


### PR DESCRIPTION
In the new payment flow released by the Payment team, an authorization retry request is triggered when a user closes the Affirm modal in checkout. When affirm-api receives an authorization retry, it loads the payment status from vbase and passes that as the response to the VTEX payment gateway. The payment status is initialized as "undefined" and is never updated if the user closes the modal. Therefore, when the authorization retry occurs, the app responds with status "undefined" and this results in the user being redirected to the Order Placed page (because "undefined" is equivalent to "payment pending"). 

This PR fixes the above situation by forcing an "undefined" status to be treated as "denied". This logic is NOT applied to the initial authorization request, only the retry. 

I've published this fix as `vtex.affirm-api@1.3.2-beta.0` and tested on sandboxusdev. I verified that closing the Affirm modal results in the user being redirected back to checkout (and not the Order Placed page) and also that Affirm orders can still be completed successfully.