### PR TITLE
[AFFIRM-14] Force minimum delayToCancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add minimum `delayToCancel` in CreatePayment response to ensure users have enough time to complete modal before authorization retry is sent
+- Log warning when authorization retry results in payment denial
+
 ### Added
 
 - SonarCloud analysis on specific branches and PR's
@@ -14,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.3.3] - 2022-01-05
 
 ### Added
+
 - Added further splunk logs
 
 ## [1.3.2] - 2021-12-10

--- a/dotnet/Services/AffirmConstants.cs
+++ b/dotnet/Services/AffirmConstants.cs
@@ -42,6 +42,8 @@ namespace Affirm.Services
 
         public const string AlreadyCaptured = "already_captured";
 
+        public const int MinimumDelayToCancel = 3600;
+
         public class Inbound
         {
             public const string ActionAuthorize = "auth";


### PR DESCRIPTION
Currently if this app cannot load settings from `vtex.affirm-payment`, or if the `delayToCancel` setting is set very low, customers will not have enough time to complete Affirm’s checkout process. The VTEX payment gateway will send an automatic authorization retry and the payment will be denied / order cancelled if the user has not yet finished the checkout. 

To prevent this scenario, this PR sets a minimum delayToCancel value of 3600 seconds (60 minutes). 

Published as `vtex.affirm-api@1.3.4-beta.0` and tested on sandboxusdev.