### PR TITLE
[AFFIRM-17] Optimize service.json settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Set recommended `service.json` values including maximum `ttl` of 60 minutes
+
 ## [1.3.4] - 2022-02-10
 
 ### Fixed

--- a/dotnet/service.json
+++ b/dotnet/service.json
@@ -1,8 +1,12 @@
 {
   "stack": "dotnet",
   "memory": 256,
-  "runtimeArgs": [
-  ],
+  "ttl": 60,
+  "timeout": 20,
+  "minReplicas": 2,
+  "maxReplicas": 4,
+  "workers": 1,
+  "runtimeArgs": [],
   "routes": {
     "printHeaders": {
       "path": "/affirm/print-headers",
@@ -48,7 +52,7 @@
   "events": {
     "onAppsLinked": {
       "sender": "apps",
-      "keys": [ "linked" ]
+      "keys": ["linked"]
     }
   }
 }


### PR DESCRIPTION
Motorola has reported timeouts when `affirm-payment` makes the request to `affirm-api` to load the payment request data. We have increased `affirm-payment`'s timeout value and this PR makes adjustments to `affirm-api`'s service configuration, most importantly setting a `ttl` of 60 minutes (instead of the default 10). This will mean that `affirm-api` is less likely to be put to sleep and therefore less likely to take a long time to respond to incoming requests.

Linked in https://b2bsuite--sandboxusdev.myvtex.com to verify build success.

You can test by sending a GET to this endpoint: http://b2bsuite--sandboxusdev.myvtex.com/affirm/payment-provider/payments/E4317C2DF179417BAD26D494CC7DF8A4/request