### PR TITLE
Handle callback failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Handle callback failure
+
 ### Changed
 
 - Cypress cy-runner.yml updated

--- a/UnitTests/AffirmAPITests.cs
+++ b/UnitTests/AffirmAPITests.cs
@@ -94,7 +94,7 @@ namespace UnitTests
         public async Task TestMethod3()
         {
             IAffirmAPI affirmAPI = new AffirmAPI(contextAccessor, httpClient, false, null);
-            dynamic response = await affirmAPI.AuthorizeAsync(publicKey, privateKey, "U5LL34ABTDS8A7DM", "1023171562818");
+            dynamic response = await affirmAPI.AuthorizeAsync(publicKey, privateKey, "U5LL34ABTDS8A7DM", "1023171562818", "");
             if (response != null)
             {
                 //response = GetDynamicValue("?xml", response);

--- a/dotnet/Data/PaymentRequestRepository.cs
+++ b/dotnet/Data/PaymentRequestRepository.cs
@@ -240,13 +240,16 @@
                 }
 
                 response = await _httpClient.SendAsync(request);
+                if(!response.IsSuccessStatusCode)
+                {
+                    _context.Vtex.Logger.Error("PostCallBackResponse", null, $"PostCallbackResponse {callbackUrl} Failed. [{response.StatusCode}] '{response.Content}' ", null);
+
+                }
             }
             catch (Exception ex)
             {
-                _context.Vtex.Logger.Error("PostCallBackResponse", null, $"PostCallbackResponse {callbackUrl} Error: {ex.Message} InnerException: {ex.InnerException} StackTrace: {ex.StackTrace}", ex);
+                _context.Vtex.Logger.Error("PostCallBackResponse", null, $"PostCallbackResponse {callbackUrl} Error", ex);
             }
-
-            response.EnsureSuccessStatusCode();
         }
 
         public async Task<VtexSettings> GetAppSettings()


### PR DESCRIPTION
If the callback fails, log and proceed.  The Payment system should re-try.