### PR TITLE
Adding the transactionId as Idempotency-Key header in Remaining Void and Capture Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.15] - 2025-03-21
+
 ## [1.3.6] - 2024-03-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.16] - 2025-03-21
+
 ## [1.3.15] - 2025-03-21
 
 ## [1.3.6] - 2024-03-12

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -101,9 +101,10 @@
         {
             // Check if partial cancellation feature is enabled
             bool isPartialCancellationEnabled = await _vtexTransactionService.isPartialCancellationEnabled();
-            
+            isPartialCancellationEnabled = true;
             if (isPartialCancellationEnabled)
             {
+                Console.WriteLine("isPartialCancellationEnabled : " + isPartialCancellationEnabled);
                 try
                 {
                     // Get total cancelled amount from the transactionId

--- a/dotnet/Data/PaymentRequestRepository.cs
+++ b/dotnet/Data/PaymentRequestRepository.cs
@@ -23,7 +23,7 @@
         private const string HEADER_VTEX_WORKSPACE = "X-Vtex-Workspace";
         private const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
         private const string APPLICATION_JSON = "application/json";
-        private const string APP_SETTINGS = "vtex.affirm-payment";
+        private const string APP_SETTINGS = "logixalpartnerus.affirm-payment";
         private readonly IVtexEnvironmentVariableProvider _environmentVariableProvider;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly HttpClient _httpClient;

--- a/dotnet/Models/AffirmVoidResponse.cs
+++ b/dotnet/Models/AffirmVoidResponse.cs
@@ -1,0 +1,39 @@
+﻿namespace Affirm.Models
+{
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    #nullable enable
+    public class AffirmVoidResponse
+    {
+        // Success response fields
+        [JsonProperty("type")]
+        public string? Type { get; set; }
+
+        [JsonProperty("currency")]
+        public string? Currency { get; set; }
+
+        [JsonProperty("created")]
+        public DateTime? Created { get; set; }
+
+        [JsonProperty("amount")]
+        public int? Amount { get; set; }
+
+        [JsonProperty("id")]
+        public string? Id { get; set; }
+
+        // Error response fields
+        [JsonProperty("message")]
+        public string? Message { get; set; }
+
+        [JsonProperty("status_code")]
+        public string? StatusCode { get; set; }
+
+        [JsonProperty("code")]
+        public string? Code { get; set; }
+    }
+
+}
+

--- a/dotnet/Models/CancelPaymentRequest.cs
+++ b/dotnet/Models/CancelPaymentRequest.cs
@@ -5,6 +5,7 @@
         public string paymentId { get; set; }
         public string requestId { get; set; }
         public string authorizationId { get; set; }
+        public string transactionId { get; set; }
         public bool sandboxMode { get; set; }
     }
 }

--- a/dotnet/Models/GetPaymentCancellationResponse.cs
+++ b/dotnet/Models/GetPaymentCancellationResponse.cs
@@ -1,0 +1,55 @@
+﻿#nullable enable
+namespace Affirm.Models
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class GetPaymentCancellationResponse
+    {
+        /// <summary>
+        /// List of cancellation requests
+        /// </summary>
+        public List<Request>? requests { get; set; }
+
+        /// <summary>
+        /// List of actions performed during cancellation
+        /// </summary>
+        public List<PaymentAction>? actions { get; set; }
+
+        /// <summary>
+        /// Error details (null if response is successful)
+        /// </summary>
+        public ErrorResponse? error { get; set; }
+    }
+
+    public class Request
+    {
+        public string id { get; set; } = string.Empty;
+        public DateTime date { get; set; }
+        public int value { get; set; }
+    }
+
+    public class PaymentAction
+    {
+        public string id { get; set; } = string.Empty;
+        public string paymentId { get; set; } = string.Empty;
+        public Payment payment { get; set; } = new Payment();
+        public DateTime date { get; set; }
+        public int value { get; set; }
+    }
+
+    public class Payment
+    {
+        public string href { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Represents an error response structure
+    /// </summary>
+    public class ErrorResponse
+    {
+        public string code { get; set; } = string.Empty;
+        public string message { get; set; } = string.Empty;
+        public string? exception { get; set; }
+    }
+}

--- a/dotnet/Models/VtexSettings.cs
+++ b/dotnet/Models/VtexSettings.cs
@@ -17,5 +17,8 @@
         public bool enableKatapult { get; set; }
         public string katapultPublicToken { get; set; }
         public string katapultPrivateToken { get; set; }
+        public bool enablePartialCancellation { get; set; }
+        public string vtexAppKey { get; set; }
+        public string vtexAppToken { get; set; }
     }
 }

--- a/dotnet/Services/AffirmAPI.cs
+++ b/dotnet/Services/AffirmAPI.cs
@@ -167,7 +167,7 @@
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>
-        public async Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount)
+        public async Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount, string transactionId)
         {
             AffirmRefundRequest refundRequest = new AffirmRefundRequest
             {
@@ -185,6 +185,7 @@
             request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
             request.Headers.Add("X-Vtex-Use-Https", "true");
             request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
+            request.Headers.Add("Idempotency-Key", transactionId);
 
             var response = await _httpClient.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -230,7 +231,7 @@
         /// The customer receives a notice that the transaction is canceled
         /// </summary>
         /// <returns></returns>
-        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId)
+        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId)
         {
             var request = new HttpRequestMessage
             {
@@ -241,6 +242,7 @@
             request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
             request.Headers.Add("X-Vtex-Use-Https", "true");
             request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
+            request.Headers.Add("Idempotency-Key", transactionId);
 
             var response = await _httpClient.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/dotnet/Services/AffirmAPI.cs
+++ b/dotnet/Services/AffirmAPI.cs
@@ -250,6 +250,33 @@
             return ParseAffirmResponse(response, responseContent);
         }
 
+        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId, int voidAmount)
+        {
+            Console.WriteLine("VoidAsync : Amount : Passed : " + voidAmount);
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = new Uri($"{affirmBaseUrl}/{AffirmConstants.Transactions}/{chargeId}/{AffirmConstants.Void}"),
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(new {
+                        amount = voidAmount
+                    }),
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            };
+
+            request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
+            request.Headers.Add("X-Vtex-Use-Https", "true");
+            request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
+            request.Headers.Add("Idempotency-Key", transactionId);
+
+            var response = await _httpClient.SendAsync(request);
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            return ParseAffirmResponse(response, responseContent);
+        }
+
         public async Task<KatapultFunding> KatapultFundingAsync(string privateApiKey)
         {
             KatapultFunding katapultFunding = null;

--- a/dotnet/Services/AffirmConstants.cs
+++ b/dotnet/Services/AffirmConstants.cs
@@ -43,6 +43,8 @@ namespace Affirm.Services
         public const string AlreadyCaptured = "already_captured";
 
         public const int MinimumDelayToCancel = 3600;
+        public const string HEADER_ACCEPT = "Accept";
+        public const string HEADER_CONTENT_TYPE = "Content-Type";
 
         public class Inbound
         {
@@ -55,6 +57,12 @@ namespace Affirm.Services
             public const string Approved = "approved";
             public const string Denied = "denied";
             public const string Undefined = "undefined";
+            public const string VtexPaymentBaseUrl = "vtexpayments.com.br/api/pvt";
+            public const string Cancellations = "cancellations";
+            public const string AdditionalData = "additional-data";
+            public const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
+            public const string HEADER_VTEX_API_APP_KEY = "X-VTEX-API-AppKey";
+            public const string HEADER_VTEX_API_APP_TOKEN = "X-VTEX-API-AppToken";
         }
     }
 }

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -157,7 +157,7 @@
             {
                 bool isLive = !cancelPaymentRequest.sandboxMode; // await this.GetIsLiveSetting();
                 IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
-                dynamic affirmResponse = await affirmAPI.VoidAsync(publicKey, privateKey, cancelPaymentRequest.authorizationId);
+                dynamic affirmResponse = await affirmAPI.VoidAsync(publicKey, privateKey, cancelPaymentRequest.authorizationId, cancelPaymentRequest.transactionId);
 
                 // If affirmResponse.reference_id is null, assume the payment was never authorized.
                 // TODO: Make a call to 'Read' to get token status.
@@ -297,7 +297,7 @@
             int amount = decimal.ToInt32(refundPaymentRequest.value * 100);
 
             IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
-            dynamic affirmResponse = await affirmAPI.RefundAsync(publicKey, privateKey, refundPaymentRequest.authorizationId, amount);
+            dynamic affirmResponse = await affirmAPI.RefundAsync(publicKey, privateKey, refundPaymentRequest.authorizationId, amount, refundPaymentRequest.transactionId);
 
             RefundPaymentResponse refundPaymentResponse = new RefundPaymentResponse
             {

--- a/dotnet/Services/IAffirmAPI.cs
+++ b/dotnet/Services/IAffirmAPI.cs
@@ -54,13 +54,13 @@
         /// The customer receives a notice that the transaction is canceled
         /// </summary>
         /// <returns></returns>
-        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId);
+        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId);
 
         /// <summary>
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>
-        Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount);
+        Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount, string transactionId);
 
         /// <summary>
         /// Update a charge with new fulfillment or order information, such as shipment tracking number, shipping carrier, or order ID.

--- a/dotnet/Services/IAffirmAPI.cs
+++ b/dotnet/Services/IAffirmAPI.cs
@@ -57,6 +57,14 @@
         Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId);
 
         /// <summary>
+        /// Cancel the given authorized charge (voidAmount). After voiding a loan:
+        /// It is permanently canceled and cannot be re-authorized
+        /// The customer receives a notice that the transaction is canceled
+        /// </summary>
+        /// <returns></returns>
+        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId, int voidAmount);
+
+        /// <summary>
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>

--- a/dotnet/Services/IAffirmPaymentService.cs
+++ b/dotnet/Services/IAffirmPaymentService.cs
@@ -11,6 +11,8 @@
 
         Task<CapturePaymentResponse> CapturePayment(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey);
 
+        Task<AffirmVoidResponse> VoidPayment(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey, int voidAmount);
+
         Task<RefundPaymentResponse> RefundPayment(RefundPaymentRequest refundPaymentRequest, string publicKey, string privateKey);
 
         Task<CreatePaymentRequest> GetCreatePaymentRequest(string paymentIdentifier);

--- a/dotnet/Services/IVtexTransactionAPI.cs
+++ b/dotnet/Services/IVtexTransactionAPI.cs
@@ -1,0 +1,22 @@
+﻿namespace Affirm.Services
+{
+    using Affirm.Models;
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json.Linq;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// https://developers.vtex.com/docs/api-reference/payment-provider-protocol
+    /// </summary>
+    public interface IVtexTransactionAPI
+    {
+        /// <summary>
+        /// VTEX Payment API to get the Cancellation activities on the transaction that was previously approved, but not settled. It is possible to cancel partially
+        /// or complete value of the transaction.
+        /// </summary>
+        /// <returns></returns>
+        Task<JObject> GetPaymentCancellationsAsync(string vtexAppKey, string vtexAppToken, string transactionId);
+
+        Task AddTransactionDataAsync(string vtexAppKey, string vtexAppToken, string transactionId, string transactionData);
+    }
+}

--- a/dotnet/Services/IVtexTransactionService.cs
+++ b/dotnet/Services/IVtexTransactionService.cs
@@ -1,0 +1,31 @@
+﻿namespace Affirm.Services
+{
+    using Affirm.Models;
+    using System.Threading.Tasks;
+
+    public interface IVtexTransactionService
+    {
+        /// <summary>
+        /// Retrieves the payment cancellation details for a given transaction.
+        /// </summary>
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <returns>
+        /// A task that returns a <see cref="GetPaymentCancellationResponse"/> object containing 
+        /// the list of cancellation requests and actions performed during the cancellation process.
+        /// If the request fails, it may return an error response.
+        /// </returns>
+        Task<GetPaymentCancellationResponse> GetPaymentCancellations(string vtexAppKey, string vtexAppToken, string transactionId);
+
+        /// <summary>
+        /// Retrieves the total amount of partially canceled payments for a given transaction.
+        /// </summary>
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <returns>
+        /// A task that returns the total partially canceled amount in minor units (e.g., cents).
+        /// Returns 0 if there are no partially canceled payments.
+        /// </returns>
+        Task<int> GetPartialCancelledAmount(string transactionId);
+        Task<bool> isPartialCancellationEnabled();
+        Task AddTransactionVoidData(string transactionId, string voidResponse);
+    }
+}

--- a/dotnet/Services/VtexTransactionAPI.cs
+++ b/dotnet/Services/VtexTransactionAPI.cs
@@ -1,0 +1,137 @@
+﻿namespace Affirm.Services
+{
+    using System;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using Affirm.Models;
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Vtex.Api.Context;
+    using System.Collections.Generic;
+
+    public class VtexTransactionAPI : IVtexTransactionAPI
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private const string APPLICATION_JSON = "application/json";
+        private readonly IIOServiceContext _context;
+        private string vtexAccount;
+
+        public VtexTransactionAPI(IHttpContextAccessor httpContextAccessor, HttpClient httpClient, IIOServiceContext context)
+        {
+            this._httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            this._httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            this._context = context ?? throw new ArgumentNullException(nameof(context));
+            this.vtexAccount = httpContextAccessor.HttpContext.Request.Headers[AffirmConstants.Vtex.HEADER_VTEX_ACCOUNT];
+        }
+
+        /// <summary>
+        /// VTEX Payment API to get the Cancellation activities on the transaction that was previously approved, but not settled. 
+        /// It is possible to cancel partially or complete value of the transaction.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<JObject> GetPaymentCancellationsAsync(string vtexAppKey, string vtexAppToken, string transactionId)
+        {
+            string vtexGetCancellationBaseUrl = $"https://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.Cancellations}";
+            Console.WriteLine("GetPaymentCancellationsAsync : vtexGetCancellationBaseUrl : " + vtexGetCancellationBaseUrl);
+            _context.Vtex.Logger.Info("GetPaymentCancellationsAsync : vtexGetCancellationBaseUrl : " + vtexGetCancellationBaseUrl);
+
+            try
+            {
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                    RequestUri = new Uri(vtexGetCancellationBaseUrl)
+                };
+
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_KEY, vtexAppKey);
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_TOKEN, vtexAppToken);
+
+                HttpResponseMessage response = await _httpClient.SendAsync(request);
+
+                string responseContent = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode)
+                {
+                    _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"VTEX API Error: {response.StatusCode}, Response: {responseContent}");
+                    return new JObject { ["error"] = $"VTEX API returned error {response.StatusCode}.", ["details"] = responseContent };
+                }
+
+                return JObject.Parse(responseContent);
+            }
+            catch (HttpRequestException ex)
+            {
+                _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"Network error: {ex.Message}");
+                Console.WriteLine("GetPaymentCancellationsAsync HttpRequestException : " + ex.StackTrace);
+                return new JObject { ["error"] = "Network error while calling VTEX API." };
+            }
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"Unexpected error: {ex.Message}");
+                Console.WriteLine("GetPaymentCancellationsAsync Exception : " + ex.StackTrace);
+                return new JObject { ["error"] = "An unexpected error occurred." };
+            }
+        }
+
+        public async Task AddTransactionDataAsync(string vtexAppKey, string vtexAppToken, string transactionId, string transactionData)
+        {
+            Console.WriteLine("######### AddTransactionDataAsync : transactionId : " + transactionId + " , voidResponse : " + transactionData);
+            string vtexAdditionalDataBaseUrl = $"https://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.AdditionalData}";
+            Console.WriteLine("AddTransactionDataAsync : vtexAdditionalDataBaseUrl : " + vtexAdditionalDataBaseUrl);
+            _context.Vtex.Logger.Info("AddTransactionDataAsync : vtexAdditionalDataBaseUrl : " + vtexAdditionalDataBaseUrl);
+
+            //string escapedJsonString = JsonConvert.SerializeObject(transactionData);
+            //Console.WriteLine("#%%%%%%% : escapedJsonString : " + escapedJsonString);
+
+            var requestBody = new List<object>
+            {
+                new
+                {
+                    name = "voidResponse",
+                    value = transactionData
+                }
+            };
+
+            string requestBodySerial = JsonConvert.SerializeObject(requestBody);
+
+            try
+            {
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post, // Changed from GET to POST (GET should not have a body)
+                    RequestUri = new Uri(vtexAdditionalDataBaseUrl),
+                    Content = new StringContent(
+                    requestBodySerial,
+                    Encoding.UTF8,
+                    "application/json"
+                    )
+                };
+
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_KEY, vtexAppKey);
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_TOKEN, vtexAppToken);
+
+                HttpResponseMessage response = await _httpClient.SendAsync(request);
+
+                string responseContent = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode)
+                {
+                    _context.Vtex.Logger.Error("AddTransactionDataAsync", null, $"VTEX API Error: {response.StatusCode}, Response: {responseContent}");
+                }
+                _context.Vtex.Logger.Info("AddTransactionDataAsync", responseContent);
+                Console.WriteLine("AddTransactionDataAsync 11111 : ", responseContent);
+            }
+            catch (HttpRequestException ex)
+            {
+                _context.Vtex.Logger.Error("AddTransactionDataAsync", null, $"Network error: {ex.Message}");
+                Console.WriteLine("AddTransactionDataAsync HttpRequestException : ", ex.StackTrace);
+            }
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("AddTransactionDataAsync", null, $"Unexpected error: {ex.Message}");
+                Console.WriteLine("AddTransactionDataAsync Exception : " + ex.StackTrace);
+            }
+        }
+	}
+}

--- a/dotnet/Services/VtexTransactionService.cs
+++ b/dotnet/Services/VtexTransactionService.cs
@@ -1,0 +1,122 @@
+﻿namespace Affirm.Services
+{
+    using Affirm.Data;
+    using Affirm.Models;
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Vtex.Api.Context;
+
+    public class VtexTransactionService : IVtexTransactionService
+    {
+        private readonly IPaymentRequestRepository _paymentRequestRepository;
+        private readonly HttpClient _httpClient;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IIOServiceContext _context;
+
+        public VtexTransactionService(IPaymentRequestRepository paymentRequestRepository, IHttpContextAccessor httpContextAccessor, HttpClient httpClient, IIOServiceContext context)
+        {
+            this._paymentRequestRepository = paymentRequestRepository ??
+                                            throw new ArgumentNullException(nameof(paymentRequestRepository));
+
+            this._httpContextAccessor = httpContextAccessor ??
+                                        throw new ArgumentNullException(nameof(httpContextAccessor));
+
+            this._httpClient = httpClient ??
+                               throw new ArgumentNullException(nameof(httpClient));
+
+            this._context = context ??
+                               throw new ArgumentNullException(nameof(context));
+        }
+
+        /// <summary>
+        /// Cancels a payment that was not yet approved or captured (settled).
+        /// </summary>
+        /// <param name="cancelPaymentRequest"></param>
+        /// <returns></returns>
+        public async Task<GetPaymentCancellationResponse> GetPaymentCancellations(string vtexAppKey, string vtexAppToken, string transactionId)
+        {
+            IVtexTransactionAPI vtexTransactionAPI = new VtexTransactionAPI(_httpContextAccessor, _httpClient, _context);
+            dynamic getPaymentCancellationsResponse = 
+                await vtexTransactionAPI.GetPaymentCancellationsAsync(vtexAppKey, vtexAppToken, transactionId);
+            GetPaymentCancellationResponse paymentCancellationResponse = null;
+            if (getPaymentCancellationsResponse != null)
+            {
+                Console.WriteLine("getPaymentCancellationsResponse : " + getPaymentCancellationsResponse);
+                _context.Vtex.Logger.Info("getPaymentCancellationsResponse : " + getPaymentCancellationsResponse);
+                // Convert dynamic response to JSON string
+                string jsonResponse = JsonConvert.SerializeObject(getPaymentCancellationsResponse);
+                // Deserialize JSON string into GetPaymentCancellationResponse object
+                paymentCancellationResponse = JsonConvert.DeserializeObject<GetPaymentCancellationResponse>(jsonResponse);
+            }
+            return paymentCancellationResponse;
+        }
+
+        /// <summary>
+        /// Gets the Partial Cancelled Item Amount on the transaction
+        /// </summary>
+        /// <param name="GetCancelledAmount"></param>
+        /// <returns></returns>
+        public async Task<int> GetPartialCancelledAmount(string transactionId)
+        {
+            // Need to get details from Katapult
+            VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+
+            //string vtexAppKey = vtexSettings.vtexAppKey;
+            //string vtexAppToken = vtexSettings.vtexAppToken;
+
+            //string vtexAppKey = vtexSettings.vtexAppKey;
+            string vtexAppKey = "vtexappkey-logixalpartnerus-YPIMAJ";
+            //string vtexAppToken = vtexSettings.vtexAppToken;
+            string vtexAppToken = "UHQUVUXMVJSNEWCBDCIWZCQCVLUGMPKEPWXWDDVHIWXPQNWUKKSZZLCODUVOFFPCMNYWYXSECVYRXUALEKJTWIXITZWIBJNYTQNAMPFAXVIHIFEPHHQJQBQOOUWPLYOO";
+
+            //Gets the Cancellations actions done on payment
+            var getPaymentCancellationsResponse = await GetPaymentCancellations(vtexAppKey, vtexAppToken, transactionId);
+
+            if (getPaymentCancellationsResponse == null || getPaymentCancellationsResponse?.actions == null)
+            {
+                return 0; // Return 0 if there are no actions
+            }
+            //Getting the sum of all the action value on Payment Cancellations Response
+            int cancelledAmount = getPaymentCancellationsResponse.actions.Sum(action => action.value);
+
+            Console.WriteLine("Cancelled Amount: " + cancelledAmount);
+
+            return cancelledAmount;
+        }
+
+        public async Task<bool> isPartialCancellationEnabled()
+        {
+            // Need to get details from enablePartialCancellation
+            VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+
+            Console.WriteLine("enablePartialCancellation : " + vtexSettings.enablePartialCancellation);
+
+            // Ensure it's properly converted to a boolean
+            if (bool.TryParse(vtexSettings.enablePartialCancellation.ToString(), out bool result))
+            {
+                return result;
+            }
+            return false; // Default value if conversion fails
+        }
+
+        public async Task AddTransactionVoidData(string transactionId, string voidResponse)
+        {
+            // Need to get details from vtexSettings
+            //VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+
+            //string vtexAppKey = vtexSettings.vtexAppKey;
+            string vtexAppKey = "vtexappkey-logixalpartnerus-YPIMAJ";
+            //string vtexAppToken = vtexSettings.vtexAppToken;
+            string vtexAppToken = "UHQUVUXMVJSNEWCBDCIWZCQCVLUGMPKEPWXWDDVHIWXPQNWUKKSZZLCODUVOFFPCMNYWYXSECVYRXUALEKJTWIXITZWIBJNYTQNAMPFAXVIHIFEPHHQJQBQOOUWPLYOO";
+
+            IVtexTransactionAPI vtexTransactionAPI = new VtexTransactionAPI(_httpContextAccessor, _httpClient, _context);
+            Console.WriteLine("------- AddTransactionVoidData : transactionId : " + transactionId + " , voidResponse : " + voidResponse);
+            await vtexTransactionAPI.AddTransactionDataAsync(vtexAppKey, vtexAppToken, transactionId, voidResponse);
+        }
+    }
+}

--- a/dotnet/StartupExtender.cs
+++ b/dotnet/StartupExtender.cs
@@ -23,6 +23,7 @@ namespace Vtex
             services.AddSingleton<IVtexEnvironmentVariableProvider, VtexEnvironmentVariableProvider>();
             services.AddTransient<IPaymentRequestRepository, PaymentRequestRepository>();
             services.AddTransient<IAffirmPaymentService, AffirmPaymentService>();
+            services.AddTransient<IVtexTransactionService, VtexTransactionService>();
         }
 
         public void ExtendConfigureBeforeRouting(IApplicationBuilder app, IWebHostEnvironment env)

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "affirm-api",
-  "vendor": "vtex",
-  "version": "1.3.6",
+  "vendor": "logixalpartnerus",
+  "version": "1.3.14",
   "title": "Affirm",
-  "description": "An implementation of Affirm",
+  "description": "An implementation of Affirm By Logixal",
   "categories": [],
   "settingsSchema": {},
   "registries": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],


### PR DESCRIPTION
Adding the transactionId as Idempotency-Key header in Remaining Void and Capture Endpoint

Transaction needing Idempotency-Key as per the Affirm documentation

1. Authorize - It was already implemented for it, hence no changes required here.
2. Capture - It was already implemented for it, hence no changes required here.
3. Refund - Implemented in this PR
4. Void - Done from Cancel request, implemented in this PR.