### PR TITLE
Added Feature to Void the amount for partially cancelled items on order when capturing the final amount on Invoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.21] - 2025-03-24
+
 ## [1.3.20] - 2025-03-24
 
 ## [1.3.19] - 2025-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.21] - 2025-03-24
 
-## [1.3.20] - 2025-03-24
+### Fixed
 
-## [1.3.19] - 2025-03-22
-
-## [1.3.18] - 2025-03-21
-
-## [1.3.17] - 2025-03-21
-
-## [1.3.16] - 2025-03-21
-
-## [1.3.15] - 2025-03-21
+ - Added Feature to Void the amount for partially cancelled items on order when capturing the final amount on Invoice
+ - Managaned by feature flag enablePartialCancellation configure in Vtex Settings of Affirm Payment App
+ - Added idempotency key for Refund and Void
 
 ## [1.3.6] - 2024-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.3.21] - 2025-03-24
+### Changed
 
-### Fixed
-
- - Added Feature to Void the amount for partially cancelled items on order when capturing the final amount on Invoice
- - Managaned by feature flag enablePartialCancellation configure in Vtex Settings of Affirm Payment App
- - Added idempotency key for Refund and Void
+- Added Feature to Void the amount for partially cancelled items on order when capturing the final amount on Invoice
+- Managaned by feature flag enablePartialCancellation configure in Vtex Settings of Affirm Payment App
+- Added idempotency key for Refund and Void
 
 ## [1.3.6] - 2024-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.15] - 2025-03-21
+
 ## [1.3.6] - 2024-03-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.19] - 2025-03-22
+
 ## [1.3.18] - 2025-03-21
 
 ## [1.3.17] - 2025-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.16] - 2025-03-21
+
 ## [1.3.15] - 2025-03-21
 
 ## [1.3.6] - 2024-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.18] - 2025-03-21
+
 ## [1.3.17] - 2025-03-21
 
 ## [1.3.16] - 2025-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.20] - 2025-03-24
+
 ## [1.3.19] - 2025-03-22
 
 ## [1.3.18] - 2025-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.17] - 2025-03-21
+
 ## [1.3.16] - 2025-03-21
 
 ## [1.3.15] - 2025-03-21

--- a/UnitTests/Fakes/FakePaymentRepository.cs
+++ b/UnitTests/Fakes/FakePaymentRepository.cs
@@ -46,5 +46,15 @@
         {
             throw new System.NotImplementedException();
         }
+
+        Task IPaymentRequestRepository.SaveVoidResponseAsync(AffirmVoidResponse affirmVoidResponse)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        Task<AffirmVoidResponse> IPaymentRequestRepository.GetVoidResponseAsync(string paymentIdentifier)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -142,7 +142,8 @@
                         if (voidResponse != null)
                         {
                             string voidResponseString = JsonConvert.SerializeObject(voidResponse);
-                            await _vtexTransactionService.AddTransactionVoidData(capturePaymentRequest.transactionId, voidResponseString);
+                            //Asynchronously adds void transaction data to the VTEX transaction API in a fire-and-forget manner.
+                            _vtexTransactionService.AddTransactionVoidData(capturePaymentRequest.transactionId, voidResponseString);
                         }
                     }
                 }

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -91,7 +91,7 @@
                 _context.Vtex.Logger.Info("CapturePayment", null, $"{bodyAsText} {JsonConvert.SerializeObject(captureResponse)}");
 
                 //Check if partial cancellation feature is enabled and void the amount if items are cancelled
-                await DoPartialCancellation(capturePaymentRequest, publicKey, paymentId);
+                await DoPartialCancellation(capturePaymentRequest, publicKey, privateKey);
 
                 return Json(captureResponse);
             }
@@ -100,8 +100,8 @@
         private async Task DoPartialCancellation(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey)
         {
             // Check if partial cancellation feature is enabled
-            bool isPartialCancellationEnabled = await _vtexTransactionService.isPartialCancellationEnabled();
-            isPartialCancellationEnabled = true;
+            //bool isPartialCancellationEnabled = await _vtexTransactionService.isPartialCancellationEnabled();
+            bool isPartialCancellationEnabled = true;
             if (isPartialCancellationEnabled)
             {
                 Console.WriteLine("isPartialCancellationEnabled : " + isPartialCancellationEnabled);

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -8,7 +8,7 @@
     using System;
     using System.Threading.Tasks;
     using Vtex.Api.Context;
-
+    
     public class RoutesController : Controller
     {
         private readonly IAffirmPaymentService _affirmPaymentService;
@@ -103,6 +103,14 @@
             bool isPartialCancellationEnabled = true;
             if (isPartialCancellationEnabled)
             {
+                bool isPartialVoidDoneForTransaction = await _vtexTransactionService.isPartialVoidDoneForTransaction(capturePaymentRequest.transactionId);
+
+                Console.WriteLine("isPartialVoidDoneForTransaction:::::" + isPartialVoidDoneForTransaction);
+                if (isPartialVoidDoneForTransaction)
+                {
+                    return; // Exit early if pisPartialVoidDoneForTransaction is true
+                }
+
                 Console.WriteLine("isPartialCancellationEnabled : " + isPartialCancellationEnabled);
                 try
                 {
@@ -115,7 +123,7 @@
                     {
                         AffirmVoidResponse voidResponse = await _affirmPaymentService.VoidPayment(capturePaymentRequest, publicKey, privateKey, cancelledAmount);
                         _context.Vtex.Logger.Info("VoidPayment", null, $"Successfully voided {cancelledAmount}.");
-                        if (voidResponse != null) 
+                        if (voidResponse != null)
                         {
                             string voidResponseString = JsonConvert.SerializeObject(voidResponse);
                             await _vtexTransactionService.AddTransactionVoidData(capturePaymentRequest.transactionId, voidResponseString);

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -87,12 +87,11 @@
             }
             else
             {
-                CapturePaymentResponse captureResponse = await this._affirmPaymentService.CapturePayment(capturePaymentRequest, publicKey, privateKey);
-                _context.Vtex.Logger.Info("CapturePayment", null, $"{bodyAsText} {JsonConvert.SerializeObject(captureResponse)}");
-
                 //Check if partial cancellation feature is enabled and void the amount if items are cancelled
                 await DoPartialCancellation(capturePaymentRequest, publicKey, privateKey);
 
+                CapturePaymentResponse captureResponse = await this._affirmPaymentService.CapturePayment(capturePaymentRequest, publicKey, privateKey);
+                _context.Vtex.Logger.Info("CapturePayment", null, $"{bodyAsText} {JsonConvert.SerializeObject(captureResponse)}");
                 return Json(captureResponse);
             }
         }

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -101,9 +101,10 @@
         {
             // Check if partial cancellation feature is enabled
             bool isPartialCancellationEnabled = await _vtexTransactionService.isPartialCancellationEnabled();
-            
+            isPartialCancellationEnabled = true;
             if (isPartialCancellationEnabled)
             {
+                Console.WriteLine("isPartialCancellationEnabled : " + isPartialCancellationEnabled);
                 try
                 {
                     // Get total cancelled amount from the transactionId

--- a/dotnet/Data/IPaymentRequestRepository.cs
+++ b/dotnet/Data/IPaymentRequestRepository.cs
@@ -21,8 +21,21 @@
 
         Task<VtexSettings> GetAppSettings();
 
+        /// <summary>
+        /// Saves the void response for a transaction asynchronously in VTEX VBase.
+        /// </summary>
+        /// <param name="affirmVoidResponse">The AffirmVoidResponse object containing transaction details.</param>
+        /// <returns>Returns a Task that represents the asynchronous operation.</returns>
         Task SaveVoidResponseAsync(AffirmVoidResponse affirmVoidResponse);
-        
+
+        /// <summary>
+        /// Retrieves the void response for a given payment ID from the VTEX VBase storage.
+        /// </summary>
+        /// <param name="paymentId">The unique identifier of the payment transaction.</param>
+        /// <returns>
+        /// An <see cref="AffirmVoidResponse"/> object containing the void response details if found;
+        /// otherwise, returns <c>null</c> if the response is not found.
+        /// </returns>
         Task<AffirmVoidResponse> GetVoidResponseAsync(string paymentIdentifier);
     }
 }

--- a/dotnet/Data/IPaymentRequestRepository.cs
+++ b/dotnet/Data/IPaymentRequestRepository.cs
@@ -20,5 +20,9 @@
         Task PostCallbackResponse(string callbackUrl, CreatePaymentResponse createPaymentResponse);
 
         Task<VtexSettings> GetAppSettings();
+
+        Task SaveVoidResponseAsync(AffirmVoidResponse affirmVoidResponse);
+        
+        Task<AffirmVoidResponse> GetVoidResponseAsync(string paymentIdentifier);
     }
 }

--- a/dotnet/Data/InMemoryPaymentRequestRepository.cs
+++ b/dotnet/Data/InMemoryPaymentRequestRepository.cs
@@ -9,13 +9,14 @@
         private readonly IDictionary<string, CreatePaymentRequest> _inMemoryDataStore = new Dictionary<string, CreatePaymentRequest>();
         private readonly IDictionary<string, CreatePaymentResponse> _inMemoryDataStoreResponse = new Dictionary<string, CreatePaymentResponse>();
         private readonly IDictionary<string, MerchantSettings> _inMemorySettings = new Dictionary<string, MerchantSettings>();
-
+        private readonly IDictionary<string, AffirmVoidResponse> _inMemoryVoidDataStore = new Dictionary<string, AffirmVoidResponse>();
+        private readonly IDictionary<string, AffirmVoidResponse> _inMemoryVoidDataStoreResponse = new Dictionary<string, AffirmVoidResponse>();
         public InMemoryPaymentRequestRepository()
         {
-            
+
         }
 
-         public Task<CreatePaymentRequest> GetPaymentRequestAsync(string paymentIdentifier)
+        public Task<CreatePaymentRequest> GetPaymentRequestAsync(string paymentIdentifier)
         {
             if (!this._inMemoryDataStore.TryGetValue(paymentIdentifier, out var paymentRequest))
             {
@@ -39,7 +40,7 @@
             return Task.CompletedTask;
         }
 
-         public Task<CreatePaymentResponse> GetPaymentResponseAsync(string paymentId)
+        public Task<CreatePaymentResponse> GetPaymentResponseAsync(string paymentId)
         {
             if (!this._inMemoryDataStoreResponse.TryGetValue(paymentId, out var paymentResponse))
             {
@@ -75,6 +76,22 @@
         public Task<VtexSettings> GetAppSettings()
         {
             throw new System.NotImplementedException();
+        }
+
+        Task IPaymentRequestRepository.SaveVoidResponseAsync(AffirmVoidResponse affirmVoidResponse)
+        {
+            this._inMemoryVoidDataStoreResponse.Remove(affirmVoidResponse.transactionId);
+            this._inMemoryVoidDataStoreResponse.Add(affirmVoidResponse.transactionId, affirmVoidResponse);
+            return Task.CompletedTask;
+        }
+
+        Task<AffirmVoidResponse> IPaymentRequestRepository.GetVoidResponseAsync(string transactionId)
+        {
+            if (!this._inMemoryVoidDataStore.TryGetValue(transactionId, out var affirmVoidResponse))
+            {
+                return Task.FromResult((AffirmVoidResponse)null);
+            }
+            return Task.FromResult(affirmVoidResponse);
         }
     }
 }

--- a/dotnet/Data/InMemoryPaymentRequestRepository.cs
+++ b/dotnet/Data/InMemoryPaymentRequestRepository.cs
@@ -13,10 +13,10 @@
         private readonly IDictionary<string, AffirmVoidResponse> _inMemoryVoidDataStoreResponse = new Dictionary<string, AffirmVoidResponse>();
         public InMemoryPaymentRequestRepository()
         {
-
+            
         }
 
-        public Task<CreatePaymentRequest> GetPaymentRequestAsync(string paymentIdentifier)
+         public Task<CreatePaymentRequest> GetPaymentRequestAsync(string paymentIdentifier)
         {
             if (!this._inMemoryDataStore.TryGetValue(paymentIdentifier, out var paymentRequest))
             {
@@ -40,7 +40,7 @@
             return Task.CompletedTask;
         }
 
-        public Task<CreatePaymentResponse> GetPaymentResponseAsync(string paymentId)
+         public Task<CreatePaymentResponse> GetPaymentResponseAsync(string paymentId)
         {
             if (!this._inMemoryDataStoreResponse.TryGetValue(paymentId, out var paymentResponse))
             {

--- a/dotnet/Data/PaymentRequestRepository.cs
+++ b/dotnet/Data/PaymentRequestRepository.cs
@@ -136,6 +136,60 @@
             response.EnsureSuccessStatusCode();
         }
 
+   public async Task SaveVoidResponseAsync(AffirmVoidResponse affirmVoidResponse)
+        {
+            
+            var jsonSerializedAffirmVoidResponse = JsonConvert.SerializeObject(affirmVoidResponse);
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Put,
+                RequestUri = new Uri($"http://vbase.{this._environmentVariableProvider.Region}.vtex.io/{this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_ACCOUNT]}/master/buckets/{this._applicationName}/{RESPONSE_BUCKET}/files/{affirmVoidResponse.transactionId}"),
+                Content = new StringContent(jsonSerializedAffirmVoidResponse, Encoding.UTF8, APPLICATION_JSON)
+            };
+
+            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
+            if (authToken != null)
+            {
+                request.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
+            }
+
+            var response = await _httpClient.SendAsync(request);
+
+            Console.WriteLine("Saved Response ::::::::::::::::::::::" + JsonConvert.SerializeObject(response));
+
+
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task<AffirmVoidResponse> GetVoidResponseAsync(string paymentId)
+        {
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri($"http://vbase.{this._environmentVariableProvider.Region}.vtex.io/{this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_ACCOUNT]}/master/buckets/{this._applicationName}/{RESPONSE_BUCKET}/files/{paymentId}"),
+            };
+
+            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
+            if (authToken != null)
+            {
+                request.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
+            }
+
+            var response = await _httpClient.SendAsync(request);
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            // A helper method is in order for this as it does not return the stack trace etc.
+            response.EnsureSuccessStatusCode();
+
+            AffirmVoidResponse paymentResponse =  JsonConvert.DeserializeObject<AffirmVoidResponse>(responseContent);
+            return paymentResponse;
+        }
+
         public async Task<CreatePaymentResponse> GetPaymentResponseAsync(string paymentId)
         {
             // Console.WriteLine($"GetPaymentRequestAsync called with {this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_ACCOUNT]},master,{this._environmentVariableProvider.ApplicationName},{this._environmentVariableProvider.ApplicationVendor},{this._environmentVariableProvider.Region}");

--- a/dotnet/Data/PaymentRequestRepository.cs
+++ b/dotnet/Data/PaymentRequestRepository.cs
@@ -23,7 +23,7 @@
         private const string HEADER_VTEX_WORKSPACE = "X-Vtex-Workspace";
         private const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
         private const string APPLICATION_JSON = "application/json";
-        private const string APP_SETTINGS = "logixalpartnerus.affirm-payment";
+        private const string APP_SETTINGS = "vtex.affirm-payment";
         private readonly IVtexEnvironmentVariableProvider _environmentVariableProvider;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly HttpClient _httpClient;

--- a/dotnet/Data/PaymentRequestRepository.cs
+++ b/dotnet/Data/PaymentRequestRepository.cs
@@ -136,7 +136,12 @@
             response.EnsureSuccessStatusCode();
         }
 
-   public async Task SaveVoidResponseAsync(AffirmVoidResponse affirmVoidResponse)
+        /// <summary>
+        /// Saves the void response for a transaction asynchronously in VTEX VBase.
+        /// </summary>
+        /// <param name="affirmVoidResponse">The AffirmVoidResponse object containing transaction details.</param>
+        /// <returns>Returns a Task that represents the asynchronous operation.</returns>
+        public async Task SaveVoidResponseAsync(AffirmVoidResponse affirmVoidResponse)
         {
             
             var jsonSerializedAffirmVoidResponse = JsonConvert.SerializeObject(affirmVoidResponse);
@@ -154,13 +159,17 @@
             }
 
             var response = await _httpClient.SendAsync(request);
-
-            Console.WriteLine("Saved Response ::::::::::::::::::::::" + JsonConvert.SerializeObject(response));
-
-
             response.EnsureSuccessStatusCode();
         }
 
+        /// <summary>
+        /// Retrieves the void response for a given payment ID from the VTEX VBase storage.
+        /// </summary>
+        /// <param name="paymentId">The unique identifier of the payment transaction.</param>
+        /// <returns>
+        /// An <see cref="AffirmVoidResponse"/> object containing the void response details if found;
+        /// otherwise, returns <c>null</c> if the response is not found.
+        /// </returns>
         public async Task<AffirmVoidResponse> GetVoidResponseAsync(string paymentId)
         {
             var request = new HttpRequestMessage

--- a/dotnet/Data/PaymentRequestRepository.cs
+++ b/dotnet/Data/PaymentRequestRepository.cs
@@ -23,7 +23,7 @@
         private const string HEADER_VTEX_WORKSPACE = "X-Vtex-Workspace";
         private const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
         private const string APPLICATION_JSON = "application/json";
-        private const string APP_SETTINGS = "vtex.affirm-payment";
+        private const string APP_SETTINGS = "logixalpartnerus.affirm-payment";
         private readonly IVtexEnvironmentVariableProvider _environmentVariableProvider;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly HttpClient _httpClient;

--- a/dotnet/Models/AffirmVoidResponse.cs
+++ b/dotnet/Models/AffirmVoidResponse.cs
@@ -1,0 +1,39 @@
+﻿namespace Affirm.Models
+{
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    #nullable enable
+    public class AffirmVoidResponse
+    {
+        // Success response fields
+        [JsonProperty("type")]
+        public string? Type { get; set; }
+
+        [JsonProperty("currency")]
+        public string? Currency { get; set; }
+
+        [JsonProperty("created")]
+        public DateTime? Created { get; set; }
+
+        [JsonProperty("amount")]
+        public int? Amount { get; set; }
+
+        [JsonProperty("id")]
+        public string? Id { get; set; }
+
+        // Error response fields
+        [JsonProperty("message")]
+        public string? Message { get; set; }
+
+        [JsonProperty("status_code")]
+        public string? StatusCode { get; set; }
+
+        [JsonProperty("code")]
+        public string? Code { get; set; }
+    }
+
+}
+

--- a/dotnet/Models/AffirmVoidResponse.cs
+++ b/dotnet/Models/AffirmVoidResponse.cs
@@ -33,6 +33,9 @@
 
         [JsonProperty("code")]
         public string? Code { get; set; }
+
+        [JsonProperty("transactionId")]
+        public string? transactionId { get; set; }
     }
 
 }

--- a/dotnet/Models/CancelPaymentRequest.cs
+++ b/dotnet/Models/CancelPaymentRequest.cs
@@ -5,6 +5,7 @@
         public string paymentId { get; set; }
         public string requestId { get; set; }
         public string authorizationId { get; set; }
+        public string transactionId { get; set; }
         public bool sandboxMode { get; set; }
     }
 }

--- a/dotnet/Models/GetPaymentCancellationResponse.cs
+++ b/dotnet/Models/GetPaymentCancellationResponse.cs
@@ -1,0 +1,55 @@
+﻿#nullable enable
+namespace Affirm.Models
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class GetPaymentCancellationResponse
+    {
+        /// <summary>
+        /// List of cancellation requests
+        /// </summary>
+        public List<Request>? requests { get; set; }
+
+        /// <summary>
+        /// List of actions performed during cancellation
+        /// </summary>
+        public List<PaymentAction>? actions { get; set; }
+
+        /// <summary>
+        /// Error details (null if response is successful)
+        /// </summary>
+        public ErrorResponse? error { get; set; }
+    }
+
+    public class Request
+    {
+        public string id { get; set; } = string.Empty;
+        public DateTime date { get; set; }
+        public int value { get; set; }
+    }
+
+    public class PaymentAction
+    {
+        public string id { get; set; } = string.Empty;
+        public string paymentId { get; set; } = string.Empty;
+        public Payment payment { get; set; } = new Payment();
+        public DateTime date { get; set; }
+        public int value { get; set; }
+    }
+
+    public class Payment
+    {
+        public string href { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Represents an error response structure
+    /// </summary>
+    public class ErrorResponse
+    {
+        public string code { get; set; } = string.Empty;
+        public string message { get; set; } = string.Empty;
+        public string? exception { get; set; }
+    }
+}

--- a/dotnet/Models/VtexSettings.cs
+++ b/dotnet/Models/VtexSettings.cs
@@ -18,7 +18,5 @@
         public string katapultPublicToken { get; set; }
         public string katapultPrivateToken { get; set; }
         public bool enablePartialCancellation { get; set; }
-        public string vtexAppKey { get; set; }
-        public string vtexAppToken { get; set; }
     }
 }

--- a/dotnet/Models/VtexSettings.cs
+++ b/dotnet/Models/VtexSettings.cs
@@ -17,5 +17,8 @@
         public bool enableKatapult { get; set; }
         public string katapultPublicToken { get; set; }
         public string katapultPrivateToken { get; set; }
+        public bool enablePartialCancellation { get; set; }
+        public string vtexAppKey { get; set; }
+        public string vtexAppToken { get; set; }
     }
 }

--- a/dotnet/Services/AffirmAPI.cs
+++ b/dotnet/Services/AffirmAPI.cs
@@ -167,7 +167,7 @@
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>
-        public async Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount)
+        public async Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount, string transactionId)
         {
             AffirmRefundRequest refundRequest = new AffirmRefundRequest
             {
@@ -185,6 +185,7 @@
             request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
             request.Headers.Add("X-Vtex-Use-Https", "true");
             request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
+            request.Headers.Add("Idempotency-Key", transactionId);
 
             var response = await _httpClient.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -230,7 +231,7 @@
         /// The customer receives a notice that the transaction is canceled
         /// </summary>
         /// <returns></returns>
-        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId)
+        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId)
         {
             var request = new HttpRequestMessage
             {
@@ -241,6 +242,7 @@
             request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
             request.Headers.Add("X-Vtex-Use-Https", "true");
             request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
+            request.Headers.Add("Idempotency-Key", transactionId);
 
             var response = await _httpClient.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/dotnet/Services/AffirmAPI.cs
+++ b/dotnet/Services/AffirmAPI.cs
@@ -250,6 +250,33 @@
             return ParseAffirmResponse(response, responseContent);
         }
 
+        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId, int voidAmount)
+        {
+            Console.WriteLine("VoidAsync : Amount : Passed : " + voidAmount);
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                RequestUri = new Uri($"{affirmBaseUrl}/{AffirmConstants.Transactions}/{chargeId}/{AffirmConstants.Void}"),
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(new {
+                        amount = voidAmount
+                    }),
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            };
+
+            request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
+            request.Headers.Add("X-Vtex-Use-Https", "true");
+            request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
+            request.Headers.Add("Idempotency-Key", transactionId);
+
+            var response = await _httpClient.SendAsync(request);
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            return ParseAffirmResponse(response, responseContent);
+        }
+
         public async Task<KatapultFunding> KatapultFundingAsync(string privateApiKey)
         {
             KatapultFunding katapultFunding = null;

--- a/dotnet/Services/AffirmAPI.cs
+++ b/dotnet/Services/AffirmAPI.cs
@@ -252,7 +252,11 @@
 
         public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, int voidAmount)
         {
-            Console.WriteLine("VoidAsync : Amount : Passed : " + voidAmount + " , chargeId : " + chargeId);
+            _context.Vtex.Logger.Info(
+                "VoidAsync",
+                null,
+                $"VoidAsync: Amount Passed: {voidAmount}, Charge ID: {chargeId}"
+            );
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
@@ -262,7 +266,7 @@
                         amount = voidAmount
                     }),
                     Encoding.UTF8,
-                    "application/json"
+                    APPLICATION_JSON
                 )
             };
 

--- a/dotnet/Services/AffirmAPI.cs
+++ b/dotnet/Services/AffirmAPI.cs
@@ -167,7 +167,7 @@
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>
-        public async Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount, string transactionId)
+        public async Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount)
         {
             AffirmRefundRequest refundRequest = new AffirmRefundRequest
             {
@@ -185,7 +185,7 @@
             request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
             request.Headers.Add("X-Vtex-Use-Https", "true");
             request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
-            request.Headers.Add("Idempotency-Key", transactionId);
+            request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
 
             var response = await _httpClient.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -231,7 +231,7 @@
         /// The customer receives a notice that the transaction is canceled
         /// </summary>
         /// <returns></returns>
-        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId)
+        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId)
         {
             var request = new HttpRequestMessage
             {
@@ -242,7 +242,7 @@
             request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
             request.Headers.Add("X-Vtex-Use-Https", "true");
             request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
-            request.Headers.Add("Idempotency-Key", transactionId);
+            request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
 
             var response = await _httpClient.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();
@@ -250,9 +250,9 @@
             return ParseAffirmResponse(response, responseContent);
         }
 
-        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId, int voidAmount)
+        public async Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, int voidAmount)
         {
-            Console.WriteLine("VoidAsync : Amount : Passed : " + voidAmount);
+            Console.WriteLine("VoidAsync : Amount : Passed : " + voidAmount + " , chargeId : " + chargeId);
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
@@ -269,7 +269,7 @@
             request.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{publicApiKey}:{privateApiKey}")));
             request.Headers.Add("X-Vtex-Use-Https", "true");
             request.Headers.Add("Proxy-Authorization", _httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL].ToString());
-            request.Headers.Add("Idempotency-Key", transactionId);
+            request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
 
             var response = await _httpClient.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();

--- a/dotnet/Services/AffirmConstants.cs
+++ b/dotnet/Services/AffirmConstants.cs
@@ -64,6 +64,9 @@ namespace Affirm.Services
             public const string HEADER_VTEX_API_APP_KEY = "X-VTEX-API-AppKey";
             public const string HEADER_VTEX_API_APP_TOKEN = "X-VTEX-API-AppToken";
             public const string VoidResponse = "voidResponse";
+            public const string ProxyAuthorization = "Proxy-Authorization";
+            public const string VtexUseHttps = "X-Vtex-Use-Https";
+            public const string VtexIdclientAutCookie = "VtexIdclientAutCookie";
         }
     }
 }

--- a/dotnet/Services/AffirmConstants.cs
+++ b/dotnet/Services/AffirmConstants.cs
@@ -26,7 +26,6 @@ namespace Affirm.Services
         public const string Void = "void";
         public const string Refund = "refund";
         public const string Update = "update";
-
         public const string AffirmUrlStub = "affirm.com";
         public const string AffirmApiVersion = "api/v1";
         public const string Charges = "charges";
@@ -45,6 +44,7 @@ namespace Affirm.Services
         public const int MinimumDelayToCancel = 3600;
         public const string HEADER_ACCEPT = "Accept";
         public const string HEADER_CONTENT_TYPE = "Content-Type";
+        public const string PartialVoid = "partial_void";
 
         public class Inbound
         {
@@ -63,6 +63,7 @@ namespace Affirm.Services
             public const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
             public const string HEADER_VTEX_API_APP_KEY = "X-VTEX-API-AppKey";
             public const string HEADER_VTEX_API_APP_TOKEN = "X-VTEX-API-AppToken";
+            public const string VoidResponse = "voidResponse";
         }
     }
 }

--- a/dotnet/Services/AffirmConstants.cs
+++ b/dotnet/Services/AffirmConstants.cs
@@ -43,6 +43,8 @@ namespace Affirm.Services
         public const string AlreadyCaptured = "already_captured";
 
         public const int MinimumDelayToCancel = 3600;
+        public const string HEADER_ACCEPT = "Accept";
+        public const string HEADER_CONTENT_TYPE = "Content-Type";
 
         public class Inbound
         {
@@ -55,6 +57,12 @@ namespace Affirm.Services
             public const string Approved = "approved";
             public const string Denied = "denied";
             public const string Undefined = "undefined";
+            public const string VtexPaymentBaseUrl = "vtexpayments.com.br/api/pvt";
+            public const string Cancellations = "cancellations";
+            public const string AdditionalData = "additional-data";
+            public const string HEADER_VTEX_ACCOUNT = "X-Vtex-Account";
+            public const string HEADER_VTEX_API_APP_KEY = "X-VTEX-API-AppKey";
+            public const string HEADER_VTEX_API_APP_TOKEN = "X-VTEX-API-AppToken";
         }
     }
 }

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -157,7 +157,7 @@
             {
                 bool isLive = !cancelPaymentRequest.sandboxMode; // await this.GetIsLiveSetting();
                 IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
-                dynamic affirmResponse = await affirmAPI.VoidAsync(publicKey, privateKey, cancelPaymentRequest.authorizationId);
+                dynamic affirmResponse = await affirmAPI.VoidAsync(publicKey, privateKey, cancelPaymentRequest.authorizationId, cancelPaymentRequest.transactionId);
 
                 // If affirmResponse.reference_id is null, assume the payment was never authorized.
                 // TODO: Make a call to 'Read' to get token status.
@@ -297,7 +297,7 @@
             int amount = decimal.ToInt32(refundPaymentRequest.value * 100);
 
             IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
-            dynamic affirmResponse = await affirmAPI.RefundAsync(publicKey, privateKey, refundPaymentRequest.authorizationId, amount);
+            dynamic affirmResponse = await affirmAPI.RefundAsync(publicKey, privateKey, refundPaymentRequest.authorizationId, amount, refundPaymentRequest.transactionId);
 
             RefundPaymentResponse refundPaymentResponse = new RefundPaymentResponse
             {

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -180,15 +180,23 @@
             return cancelPaymentResponse;
         }
 
+        /// <summary>
+        /// Attempts to void a payment for a given transaction.
+        /// Retrieves the original payment request, sends a void request to Affirm, and saves the response.
+        /// </summary>
+        /// <param name="capturePaymentRequest">The capture payment request containing transaction details.</param>
+        /// <param name="publicKey">The public key for API authentication.</param>
+        /// <param name="privateKey">The private key for API authentication.</param>
+        /// <param name="voidAmount">The amount to be voided.</param>
+        /// <returns>Returns an <see cref="AffirmVoidResponse"/> object if successful, otherwise null.</returns>
         public async Task<AffirmVoidResponse> VoidPayment(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey, int voidAmount)
         {
             AffirmVoidResponse voidResponse = null;
-
             // Load request from storage for order id
             CreatePaymentRequest paymentRequest = await this._paymentRequestRepository.GetPaymentRequestAsync(capturePaymentRequest.paymentId);
             if (paymentRequest == null)
             {
-                _context.Vtex.Logger.Warn("CancelPayment", null, $"Could not load Payment Request for Payment Id: {capturePaymentRequest.paymentId}");
+                _context.Vtex.Logger.Warn("VoidPayment", null, $"Could not load Payment Request for Payment Id: {capturePaymentRequest.paymentId}");
             }
             else
             {
@@ -198,19 +206,24 @@
 
             if (!string.IsNullOrEmpty(capturePaymentRequest.authorizationId))
             {
-                bool isLive = !capturePaymentRequest.sandboxMode; // await this.GetIsLiveSetting();
+                bool isLive = !capturePaymentRequest.sandboxMode;
                 IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
                 dynamic response = await affirmAPI.VoidAsync(publicKey, privateKey, capturePaymentRequest.authorizationId, voidAmount);
+                //If VoidAsync response is not null, then save the response if it's success.
                 if (response != null) 
                 {
                     string jsonResponse = JsonConvert.SerializeObject(response);
                     voidResponse = JsonConvert.DeserializeObject<AffirmVoidResponse>(jsonResponse);
                 
-                    if (voidResponse?.Type == "partial_void")
+                    if (voidResponse?.Type == AffirmConstants.PartialVoid)
                     {
                         voidResponse.transactionId = capturePaymentRequest.transactionId;
                         await _paymentRequestRepository.SaveVoidResponseAsync(voidResponse);
-                        Console.WriteLine("Saved:::::::::::::::" + JsonConvert.SerializeObject(voidResponse));
+                        _context.Vtex.Logger.Info(
+                            "VoidPayment",
+                            null,
+                            $"Saved void response for Transaction ID: {voidResponse.transactionId}, Response: {JsonConvert.SerializeObject(voidResponse)}"
+                        );
                     }
                 }
             }

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -205,6 +205,13 @@
                 {
                     string jsonResponse = JsonConvert.SerializeObject(response);
                     voidResponse = JsonConvert.DeserializeObject<AffirmVoidResponse>(jsonResponse);
+                
+                    if (voidResponse?.Type == "partial_void")
+                    {
+                        voidResponse.transactionId = capturePaymentRequest.transactionId;
+                        await _paymentRequestRepository.SaveVoidResponseAsync(voidResponse);
+                        Console.WriteLine("Saved:::::::::::::::" + JsonConvert.SerializeObject(voidResponse));
+                    }
                 }
             }
             return voidResponse;

--- a/dotnet/Services/AffirmPaymentService.cs
+++ b/dotnet/Services/AffirmPaymentService.cs
@@ -157,7 +157,7 @@
             {
                 bool isLive = !cancelPaymentRequest.sandboxMode; // await this.GetIsLiveSetting();
                 IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
-                dynamic affirmResponse = await affirmAPI.VoidAsync(publicKey, privateKey, cancelPaymentRequest.authorizationId, cancelPaymentRequest.transactionId);
+                dynamic affirmResponse = await affirmAPI.VoidAsync(publicKey, privateKey, cancelPaymentRequest.authorizationId);
 
                 // If affirmResponse.reference_id is null, assume the payment was never authorized.
                 // TODO: Make a call to 'Read' to get token status.
@@ -200,7 +200,7 @@
             {
                 bool isLive = !capturePaymentRequest.sandboxMode; // await this.GetIsLiveSetting();
                 IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
-                dynamic response = await affirmAPI.VoidAsync(publicKey, privateKey, capturePaymentRequest.authorizationId, capturePaymentRequest.transactionId, voidAmount);
+                dynamic response = await affirmAPI.VoidAsync(publicKey, privateKey, capturePaymentRequest.authorizationId, voidAmount);
                 if (response != null) 
                 {
                     string jsonResponse = JsonConvert.SerializeObject(response);
@@ -327,7 +327,7 @@
             int amount = decimal.ToInt32(refundPaymentRequest.value * 100);
 
             IAffirmAPI affirmAPI = new AffirmAPI(_httpContextAccessor, _httpClient, isLive, _context);
-            dynamic affirmResponse = await affirmAPI.RefundAsync(publicKey, privateKey, refundPaymentRequest.authorizationId, amount, refundPaymentRequest.transactionId);
+            dynamic affirmResponse = await affirmAPI.RefundAsync(publicKey, privateKey, refundPaymentRequest.authorizationId, amount);
 
             RefundPaymentResponse refundPaymentResponse = new RefundPaymentResponse
             {

--- a/dotnet/Services/IAffirmAPI.cs
+++ b/dotnet/Services/IAffirmAPI.cs
@@ -54,13 +54,13 @@
         /// The customer receives a notice that the transaction is canceled
         /// </summary>
         /// <returns></returns>
-        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId);
+        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId);
 
         /// <summary>
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>
-        Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount);
+        Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount, string transactionId);
 
         /// <summary>
         /// Update a charge with new fulfillment or order information, such as shipment tracking number, shipping carrier, or order ID.

--- a/dotnet/Services/IAffirmAPI.cs
+++ b/dotnet/Services/IAffirmAPI.cs
@@ -54,7 +54,7 @@
         /// The customer receives a notice that the transaction is canceled
         /// </summary>
         /// <returns></returns>
-        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId);
+        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId);
 
         /// <summary>
         /// Cancel the given authorized charge (voidAmount). After voiding a loan:
@@ -62,13 +62,13 @@
         /// The customer receives a notice that the transaction is canceled
         /// </summary>
         /// <returns></returns>
-        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId, int voidAmount);
+        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, int voidAmount);
 
         /// <summary>
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>
-        Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount, string transactionId);
+        Task<JObject> RefundAsync(string publicApiKey, string privateApiKey, string chargeId, int amount);
 
         /// <summary>
         /// Update a charge with new fulfillment or order information, such as shipment tracking number, shipping carrier, or order ID.

--- a/dotnet/Services/IAffirmAPI.cs
+++ b/dotnet/Services/IAffirmAPI.cs
@@ -57,6 +57,14 @@
         Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId);
 
         /// <summary>
+        /// Cancel the given authorized charge (voidAmount). After voiding a loan:
+        /// It is permanently canceled and cannot be re-authorized
+        /// The customer receives a notice that the transaction is canceled
+        /// </summary>
+        /// <returns></returns>
+        Task<JObject> VoidAsync(string publicApiKey, string privateApiKey, string chargeId, string transactionId, int voidAmount);
+
+        /// <summary>
         /// Refund a charge. (add link to refund info)
         /// </summary>
         /// <returns></returns>

--- a/dotnet/Services/IAffirmPaymentService.cs
+++ b/dotnet/Services/IAffirmPaymentService.cs
@@ -11,6 +11,8 @@
 
         Task<CapturePaymentResponse> CapturePayment(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey);
 
+        Task<AffirmVoidResponse> VoidPayment(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey, int voidAmount);
+
         Task<RefundPaymentResponse> RefundPayment(RefundPaymentRequest refundPaymentRequest, string publicKey, string privateKey);
 
         Task<CreatePaymentRequest> GetCreatePaymentRequest(string paymentIdentifier);

--- a/dotnet/Services/IAffirmPaymentService.cs
+++ b/dotnet/Services/IAffirmPaymentService.cs
@@ -11,6 +11,15 @@
 
         Task<CapturePaymentResponse> CapturePayment(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey);
 
+        /// <summary>
+        /// Attempts to void a payment for a given transaction.
+        /// Retrieves the original payment request, sends a void request to Affirm, and saves the response.
+        /// </summary>
+        /// <param name="capturePaymentRequest">The capture payment request containing transaction details.</param>
+        /// <param name="publicKey">The public key for API authentication.</param>
+        /// <param name="privateKey">The private key for API authentication.</param>
+        /// <param name="voidAmount">The amount to be voided.</param>
+        /// <returns>Returns an <see cref="AffirmVoidResponse"/> object if successful, otherwise null.</returns>
         Task<AffirmVoidResponse> VoidPayment(CapturePaymentRequest capturePaymentRequest, string publicKey, string privateKey, int voidAmount);
 
         Task<RefundPaymentResponse> RefundPayment(RefundPaymentRequest refundPaymentRequest, string publicKey, string privateKey);

--- a/dotnet/Services/IVtexTransactionAPI.cs
+++ b/dotnet/Services/IVtexTransactionAPI.cs
@@ -1,0 +1,22 @@
+﻿namespace Affirm.Services
+{
+    using Affirm.Models;
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json.Linq;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// https://developers.vtex.com/docs/api-reference/payment-provider-protocol
+    /// </summary>
+    public interface IVtexTransactionAPI
+    {
+        /// <summary>
+        /// VTEX Payment API to get the Cancellation activities on the transaction that was previously approved, but not settled. It is possible to cancel partially
+        /// or complete value of the transaction.
+        /// </summary>
+        /// <returns></returns>
+        Task<JObject> GetPaymentCancellationsAsync(string vtexAppKey, string vtexAppToken, string transactionId);
+
+        Task AddTransactionDataAsync(string vtexAppKey, string vtexAppToken, string transactionId, string transactionData);
+    }
+}

--- a/dotnet/Services/IVtexTransactionAPI.cs
+++ b/dotnet/Services/IVtexTransactionAPI.cs
@@ -15,16 +15,14 @@
         /// or complete value of the transaction.
         /// </summary>
         /// <returns>Task representing the asynchronous operation for getting cancellation done on transaction</returns>
-        Task<JObject> GetPaymentCancellationsAsync(string vtexAppKey, string vtexAppToken, string transactionId);
+        Task<JObject> GetPaymentCancellationsAsync(string transactionId);
 
         /// <summary>
         /// Adds void response data to a VTEX transaction's additional data.
         /// </summary>
-        /// <param name="vtexAppKey">The VTEX application key for authentication.</param>
-        /// <param name="vtexAppToken">The VTEX application token for authentication.</param>
         /// <param name="transactionId">The transaction ID to which the void response data is added.</param>
         /// <param name="transactionData">The serialized void response data to be stored.</param>
         /// <returns>A Task representing the asynchronous operation for adding data to transaction</returns>
-        Task AddTransactionDataAsync(string vtexAppKey, string vtexAppToken, string transactionId, string transactionData);
+        Task AddTransactionDataAsync(string transactionId, string transactionData);
     }
 }

--- a/dotnet/Services/IVtexTransactionAPI.cs
+++ b/dotnet/Services/IVtexTransactionAPI.cs
@@ -14,9 +14,17 @@
         /// VTEX Payment API to get the Cancellation activities on the transaction that was previously approved, but not settled. It is possible to cancel partially
         /// or complete value of the transaction.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Task representing the asynchronous operation for getting cancellation done on transaction</returns>
         Task<JObject> GetPaymentCancellationsAsync(string vtexAppKey, string vtexAppToken, string transactionId);
 
+        /// <summary>
+        /// Adds void response data to a VTEX transaction's additional data.
+        /// </summary>
+        /// <param name="vtexAppKey">The VTEX application key for authentication.</param>
+        /// <param name="vtexAppToken">The VTEX application token for authentication.</param>
+        /// <param name="transactionId">The transaction ID to which the void response data is added.</param>
+        /// <param name="transactionData">The serialized void response data to be stored.</param>
+        /// <returns>A Task representing the asynchronous operation for adding data to transaction</returns>
         Task AddTransactionDataAsync(string vtexAppKey, string vtexAppToken, string transactionId, string transactionData);
     }
 }

--- a/dotnet/Services/IVtexTransactionService.cs
+++ b/dotnet/Services/IVtexTransactionService.cs
@@ -1,0 +1,31 @@
+﻿namespace Affirm.Services
+{
+    using Affirm.Models;
+    using System.Threading.Tasks;
+
+    public interface IVtexTransactionService
+    {
+        /// <summary>
+        /// Retrieves the payment cancellation details for a given transaction.
+        /// </summary>
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <returns>
+        /// A task that returns a <see cref="GetPaymentCancellationResponse"/> object containing 
+        /// the list of cancellation requests and actions performed during the cancellation process.
+        /// If the request fails, it may return an error response.
+        /// </returns>
+        Task<GetPaymentCancellationResponse> GetPaymentCancellations(string vtexAppKey, string vtexAppToken, string transactionId);
+
+        /// <summary>
+        /// Retrieves the total amount of partially canceled payments for a given transaction.
+        /// </summary>
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <returns>
+        /// A task that returns the total partially canceled amount in minor units (e.g., cents).
+        /// Returns 0 if there are no partially canceled payments.
+        /// </returns>
+        Task<int> GetPartialCancelledAmount(string transactionId);
+        Task<bool> isPartialCancellationEnabled();
+        Task AddTransactionVoidData(string transactionId, string voidResponse);
+    }
+}

--- a/dotnet/Services/IVtexTransactionService.cs
+++ b/dotnet/Services/IVtexTransactionService.cs
@@ -14,7 +14,7 @@
         /// the list of cancellation requests and actions performed during the cancellation process.
         /// If the request fails, it may return an error response.
         /// </returns>
-        Task<GetPaymentCancellationResponse> GetPaymentCancellations(string vtexAppKey, string vtexAppToken, string transactionId);
+        Task<GetPaymentCancellationResponse> GetPaymentCancellations(string transactionId);
 
         /// <summary>
         /// Retrieves the total amount of partially cancelled items payments for a given transaction.
@@ -39,12 +39,15 @@
         Task<bool> isPartialCancellationEnabled();
 
         /// <summary>
-        /// Adds void transaction data to VTEX if valid credentials are available.
+        /// Asynchronously adds void transaction data to the VTEX transaction API in a fire-and-forget manner.
         /// </summary>
-        /// <param name="transactionId">The transaction ID for which the void data is being added.</param>
-        /// <param name="voidResponse">The void response data in JSON format.</param>
-        /// <returns>A task representing the asynchronous operation for Adding Transaction data</returns>
-        Task AddTransactionVoidData(string transactionId, string voidResponse);
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <param name="voidResponse">The serialized response data related to the void transaction.</param>
+        /// <remarks>
+        /// This method executes the API call in the background using `Task.Run`, ensuring that it does not block the main thread.
+        /// Any exceptions encountered are logged to prevent unhandled errors.
+        /// </remarks>
+        void AddTransactionVoidData(string transactionId, string voidResponse);
 
         /// <summary>
         /// Checks whether a partial void has been processed for a given transaction.

--- a/dotnet/Services/IVtexTransactionService.cs
+++ b/dotnet/Services/IVtexTransactionService.cs
@@ -27,5 +27,6 @@
         Task<int> GetPartialCancelledAmount(string transactionId);
         Task<bool> isPartialCancellationEnabled();
         Task AddTransactionVoidData(string transactionId, string voidResponse);
+        Task<bool> isPartialVoidDoneForTransaction(string transactionId);
     }
 }

--- a/dotnet/Services/IVtexTransactionService.cs
+++ b/dotnet/Services/IVtexTransactionService.cs
@@ -17,16 +17,43 @@
         Task<GetPaymentCancellationResponse> GetPaymentCancellations(string vtexAppKey, string vtexAppToken, string transactionId);
 
         /// <summary>
-        /// Retrieves the total amount of partially canceled payments for a given transaction.
+        /// Retrieves the total amount of partially cancelled items payments for a given transaction.
         /// </summary>
         /// <param name="transactionId">The unique identifier of the transaction.</param>
         /// <returns>
         /// A task that returns the total partially canceled amount in minor units (e.g., cents).
-        /// Returns 0 if there are no partially canceled payments.
+        /// Returns 0 if there are no partially cancelled payments.
         /// </returns>
         Task<int> GetPartialCancelledAmount(string transactionId);
+
+        /// <summary>
+        /// Checks if the partial cancellation feature is enabled in VTEX settings.
+        /// </summary>
+        /// <returns>
+        /// A boolean indicating whether partial cancellation is enabled.
+        /// Returns <c>false</c> if the setting is <c>null</c> or in case of any exception.
+        /// </returns>
+        /// <exception cref="Exception">
+        /// Catches any exception that occurs while retrieving settings and logs the error.
+        /// </exception>
         Task<bool> isPartialCancellationEnabled();
+
+        /// <summary>
+        /// Adds void transaction data to VTEX if valid credentials are available.
+        /// </summary>
+        /// <param name="transactionId">The transaction ID for which the void data is being added.</param>
+        /// <param name="voidResponse">The void response data in JSON format.</param>
+        /// <returns>A task representing the asynchronous operation for Adding Transaction data</returns>
         Task AddTransactionVoidData(string transactionId, string voidResponse);
+
+        /// <summary>
+        /// Checks whether a partial void has been processed for a given transaction.
+        /// </summary>
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <returns>
+        /// A boolean indicating whether a partial void has been processed for the transaction.
+        /// Returns <c>true</c> if a void response exists; otherwise, returns <c>false</c>.
+        /// </returns>
         Task<bool> isPartialVoidDoneForTransaction(string transactionId);
     }
 }

--- a/dotnet/Services/VtexTransactionAPI.cs
+++ b/dotnet/Services/VtexTransactionAPI.cs
@@ -33,9 +33,9 @@
         /// It is possible to cancel partially or complete value of the transaction.
         /// </summary>
         /// <returns>Task representing the asynchronous operation for getting cancellation done on transaction</returns>
-        public async Task<JObject> GetPaymentCancellationsAsync(string vtexAppKey, string vtexAppToken, string transactionId)
+        public async Task<JObject> GetPaymentCancellationsAsync(string transactionId)
         {
-            string vtexGetCancellationBaseUrl = $"https://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.Cancellations}";
+            string vtexGetCancellationBaseUrl = $"http://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.Cancellations}";
             _context.Vtex.Logger.Info("GetPaymentCancellationsAsync : vtexGetCancellationBaseUrl : " + vtexGetCancellationBaseUrl);
 
             try
@@ -46,8 +46,9 @@
                     RequestUri = new Uri(vtexGetCancellationBaseUrl)
                 };
 
-                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_KEY, vtexAppKey);
-                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_TOKEN, vtexAppToken);
+                request.Headers.Add(AffirmConstants.Vtex.VtexIdclientAutCookie, _context.Vtex.AuthToken);
+                request.Headers.Add(AffirmConstants.Vtex.VtexUseHttps, "true");
+                request.Headers.Add(AffirmConstants.Vtex.ProxyAuthorization, _context.Vtex.AuthToken);
 
                 HttpResponseMessage response = await _httpClient.SendAsync(request);
 
@@ -75,15 +76,13 @@
         /// <summary>
         /// Adds void response data to a VTEX transaction's additional data.
         /// </summary>
-        /// <param name="vtexAppKey">The VTEX application key for authentication.</param>
-        /// <param name="vtexAppToken">The VTEX application token for authentication.</param>
         /// <param name="transactionId">The transaction ID to which the void response data is added.</param>
         /// <param name="transactionData">The serialized void response data to be stored.</param>
         /// <returns>A Task representing the asynchronous operation for adding data to transaction</returns>
-        public async Task AddTransactionDataAsync(string vtexAppKey, string vtexAppToken, string transactionId, string transactionData)
+        public async Task AddTransactionDataAsync(string transactionId, string transactionData)
         {
             _context.Vtex.Logger.Info("AddTransactionDataAsync", null, $"Adding Void Response data for TransactionId: {transactionId} : VoidResponse: {transactionData}");
-            string vtexAdditionalDataBaseUrl = $"https://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.AdditionalData}";
+            string vtexAdditionalDataBaseUrl = $"http://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.AdditionalData}";
 
             var requestBody = new List<object>
             {
@@ -109,8 +108,9 @@
                     )
                 };
 
-                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_KEY, vtexAppKey);
-                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_TOKEN, vtexAppToken);
+                request.Headers.Add(AffirmConstants.Vtex.VtexIdclientAutCookie, _context.Vtex.AuthToken);
+                request.Headers.Add(AffirmConstants.Vtex.VtexUseHttps, "true");
+                request.Headers.Add(AffirmConstants.Vtex.ProxyAuthorization, _context.Vtex.AuthToken);
 
                 //Making the additional-data call to save response on Transaction
                 HttpResponseMessage response = await _httpClient.SendAsync(request);

--- a/dotnet/Services/VtexTransactionAPI.cs
+++ b/dotnet/Services/VtexTransactionAPI.cs
@@ -62,14 +62,12 @@
             }
             catch (HttpRequestException ex)
             {
-                _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"Network error: {ex.Message}");
-                Console.WriteLine("GetPaymentCancellationsAsync HttpRequestException : " + ex.StackTrace);
+                _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"HttpRequestException error: {ex.Message}");
                 return new JObject { ["error"] = "Network error while calling VTEX API." };
             }
             catch (Exception ex)
             {
                 _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"Unexpected error: {ex.Message}");
-                Console.WriteLine("GetPaymentCancellationsAsync Exception : " + ex.StackTrace);
                 return new JObject { ["error"] = "An unexpected error occurred." };
             }
         }

--- a/dotnet/Services/VtexTransactionAPI.cs
+++ b/dotnet/Services/VtexTransactionAPI.cs
@@ -1,0 +1,137 @@
+﻿namespace Affirm.Services
+{
+    using System;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using Affirm.Models;
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Vtex.Api.Context;
+    using System.Collections.Generic;
+
+    public class VtexTransactionAPI : IVtexTransactionAPI
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private const string APPLICATION_JSON = "application/json";
+        private readonly IIOServiceContext _context;
+        private string vtexAccount;
+
+        public VtexTransactionAPI(IHttpContextAccessor httpContextAccessor, HttpClient httpClient, IIOServiceContext context)
+        {
+            this._httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+            this._httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            this._context = context ?? throw new ArgumentNullException(nameof(context));
+            this.vtexAccount = httpContextAccessor.HttpContext.Request.Headers[AffirmConstants.Vtex.HEADER_VTEX_ACCOUNT];
+        }
+
+        /// <summary>
+        /// VTEX Payment API to get the Cancellation activities on the transaction that was previously approved, but not settled. 
+        /// It is possible to cancel partially or complete value of the transaction.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<JObject> GetPaymentCancellationsAsync(string vtexAppKey, string vtexAppToken, string transactionId)
+        {
+            string vtexGetCancellationBaseUrl = $"https://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.Cancellations}";
+            Console.WriteLine("GetPaymentCancellationsAsync : vtexGetCancellationBaseUrl : " + vtexGetCancellationBaseUrl);
+            _context.Vtex.Logger.Info("GetPaymentCancellationsAsync : vtexGetCancellationBaseUrl : " + vtexGetCancellationBaseUrl);
+
+            try
+            {
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                    RequestUri = new Uri(vtexGetCancellationBaseUrl)
+                };
+
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_KEY, vtexAppKey);
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_TOKEN, vtexAppToken);
+
+                HttpResponseMessage response = await _httpClient.SendAsync(request);
+
+                string responseContent = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode)
+                {
+                    _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"VTEX API Error: {response.StatusCode}, Response: {responseContent}");
+                    return new JObject { ["error"] = $"VTEX API returned error {response.StatusCode}.", ["details"] = responseContent };
+                }
+
+                return JObject.Parse(responseContent);
+            }
+            catch (HttpRequestException ex)
+            {
+                _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"Network error: {ex.Message}");
+                Console.WriteLine("GetPaymentCancellationsAsync HttpRequestException : " + ex.StackTrace);
+                return new JObject { ["error"] = "Network error while calling VTEX API." };
+            }
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("GetPaymentCancellationsAsync", null, $"Unexpected error: {ex.Message}");
+                Console.WriteLine("GetPaymentCancellationsAsync Exception : " + ex.StackTrace);
+                return new JObject { ["error"] = "An unexpected error occurred." };
+            }
+        }
+
+        public async Task AddTransactionDataAsync(string vtexAppKey, string vtexAppToken, string transactionId, string transactionData)
+        {
+            Console.WriteLine("######### AddTransactionDataAsync : transactionId : " + transactionId + " , voidResponse : " + transactionData);
+            string vtexAdditionalDataBaseUrl = $"https://{this.vtexAccount}.{AffirmConstants.Vtex.VtexPaymentBaseUrl}/{AffirmConstants.Transactions}/{transactionId}/{AffirmConstants.Vtex.AdditionalData}";
+            Console.WriteLine("AddTransactionDataAsync : vtexAdditionalDataBaseUrl : " + vtexAdditionalDataBaseUrl);
+            _context.Vtex.Logger.Info("AddTransactionDataAsync : vtexAdditionalDataBaseUrl : " + vtexAdditionalDataBaseUrl);
+
+            //string escapedJsonString = JsonConvert.SerializeObject(transactionData);
+            //Console.WriteLine("#%%%%%%% : escapedJsonString : " + escapedJsonString);
+
+            var requestBody = new List<object>
+            {
+                new
+                {
+                    name = "voidResponse",
+                    value = transactionData
+                }
+            };
+
+            string requestBodySerial = JsonConvert.SerializeObject(requestBody);
+
+            try
+            {
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post, // Changed from GET to POST (GET should not have a body)
+                    RequestUri = new Uri(vtexAdditionalDataBaseUrl),
+                    Content = new StringContent(
+                    requestBodySerial,
+                    Encoding.UTF8,
+                    "application/json"
+                    )
+                };
+
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_KEY, vtexAppKey);
+                request.Headers.Add(AffirmConstants.Vtex.HEADER_VTEX_API_APP_TOKEN, vtexAppToken);
+
+                HttpResponseMessage response = await _httpClient.SendAsync(request);
+
+                string responseContent = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode)
+                {
+                    _context.Vtex.Logger.Error("AddTransactionDataAsync", null, $"VTEX API Error: {response.StatusCode}, Response: {responseContent}");
+                }
+                _context.Vtex.Logger.Info("AddTransactionDataAsync", responseContent);
+                Console.WriteLine("AddTransactionDataAsync 11111 : ", responseContent);
+            }
+            catch (HttpRequestException ex)
+            {
+                _context.Vtex.Logger.Error("AddTransactionDataAsync", null, $"Network error: {ex.Message}");
+                Console.WriteLine("AddTransactionDataAsync HttpRequestException : ", ex.StackTrace);
+            }
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("AddTransactionDataAsync", null, $"Unexpected error: {ex.Message}");
+                Console.WriteLine("AddTransactionDataAsync Exception : " + ex.StackTrace);
+            }
+        }
+	}
+}

--- a/dotnet/Services/VtexTransactionService.cs
+++ b/dotnet/Services/VtexTransactionService.cs
@@ -41,13 +41,11 @@
         public async Task<GetPaymentCancellationResponse> GetPaymentCancellations(string vtexAppKey, string vtexAppToken, string transactionId)
         {
             IVtexTransactionAPI vtexTransactionAPI = new VtexTransactionAPI(_httpContextAccessor, _httpClient, _context);
-            dynamic getPaymentCancellationsResponse = 
+            dynamic getPaymentCancellationsResponse =
                 await vtexTransactionAPI.GetPaymentCancellationsAsync(vtexAppKey, vtexAppToken, transactionId);
             GetPaymentCancellationResponse paymentCancellationResponse = null;
             if (getPaymentCancellationsResponse != null)
             {
-                Console.WriteLine("getPaymentCancellationsResponse : " + getPaymentCancellationsResponse);
-                _context.Vtex.Logger.Info("getPaymentCancellationsResponse : " + getPaymentCancellationsResponse);
                 // Convert dynamic response to JSON string
                 string jsonResponse = JsonConvert.SerializeObject(getPaymentCancellationsResponse);
                 // Deserialize JSON string into GetPaymentCancellationResponse object
@@ -57,22 +55,27 @@
         }
 
         /// <summary>
-        /// Gets the Partial Cancelled Item Amount on the transaction
+        /// Retrieves the total amount of partially cancelled items payments for a given transaction.
         /// </summary>
-        /// <param name="GetCancelledAmount"></param>
-        /// <returns></returns>
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <returns>
+        /// A task that returns the total partially canceled amount in minor units (e.g., cents).
+        /// Returns 0 if there are no partially cancelled payments.
+        /// </returns>
         public async Task<int> GetPartialCancelledAmount(string transactionId)
         {
-            // Need to get details from Katapult
+            // Need to get details from VTEX App key and Token
             VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
 
-            //string vtexAppKey = vtexSettings.vtexAppKey;
-            //string vtexAppToken = vtexSettings.vtexAppToken;
+            string vtexAppKey = vtexSettings.vtexAppKey;
+            string vtexAppToken = vtexSettings.vtexAppToken;
 
-            //string vtexAppKey = vtexSettings.vtexAppKey;
-            string vtexAppKey = "vtexappkey-logixalpartnerus-YPIMAJ";
-            //string vtexAppToken = vtexSettings.vtexAppToken;
-            string vtexAppToken = "UHQUVUXMVJSNEWCBDCIWZCQCVLUGMPKEPWXWDDVHIWXPQNWUKKSZZLCODUVOFFPCMNYWYXSECVYRXUALEKJTWIXITZWIBJNYTQNAMPFAXVIHIFEPHHQJQBQOOUWPLYOO";
+            // Validate credentials
+            if (string.IsNullOrWhiteSpace(vtexAppKey) || string.IsNullOrWhiteSpace(vtexAppToken))
+            {
+                _context.Vtex.Logger.Warn("GetPartialCancelledAmount", null, "VTEX App Key or Token is missing.");
+                return 0;
+            }
 
             //Gets the Cancellations actions done on payment
             var getPaymentCancellationsResponse = await GetPaymentCancellations(vtexAppKey, vtexAppToken, transactionId);
@@ -84,55 +87,93 @@
             //Getting the sum of all the action value on Payment Cancellations Response
             int cancelledAmount = getPaymentCancellationsResponse.actions.Sum(action => action.value);
 
-            Console.WriteLine("Cancelled Amount: " + cancelledAmount);
+            _context.Vtex.Logger.Info(
+                "GetPartialCancelledAmount",
+                null,
+                $"Cancelled Amount: {cancelledAmount} on Transaction ID: {transactionId}"
+            );
 
             return cancelledAmount;
         }
 
+        /// <summary>
+        /// Checks if the partial cancellation feature is enabled in VTEX settings.
+        /// </summary>
+        /// <returns>
+        /// A boolean indicating whether partial cancellation is enabled.
+        /// Returns <c>false</c> if the setting is <c>null</c> or in case of any exception.
+        /// </returns>
+        /// <exception cref="Exception">
+        /// Catches any exception that occurs while retrieving settings and logs the error.
+        /// </exception>
         public async Task<bool> isPartialCancellationEnabled()
         {
-            // Need to get details from enablePartialCancellation
-            VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
-
-            Console.WriteLine("enablePartialCancellation : " + vtexSettings.enablePartialCancellation);
-
-            // Ensure it's properly converted to a boolean
-            if (bool.TryParse(vtexSettings.enablePartialCancellation.ToString(), out bool result))
+            try
             {
-                return result;
+                // Ensure vtexSettings is not null
+                VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+
+                // Log the enablePartialCancellation value
+                _context.Vtex.Logger.Info("isPartialCancellationEnabled", null, $"enablePartialCancellation: {vtexSettings.enablePartialCancellation}");
+
+                // Directly return the value for enablePartialCancellation
+                return vtexSettings.enablePartialCancellation;
             }
-            return false; // Default value if conversion fails
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("isPartialCancellationEnabled", null, $"Exception occurred: {ex.Message}");
+                return false; // Return false in case of any failure
+            }
         }
 
+        /// <summary>
+        /// Adds void transaction data to VTEX if valid credentials are available.
+        /// </summary>
+        /// <param name="transactionId">The transaction ID for which the void data is being added.</param>
+        /// <param name="voidResponse">The void response data in JSON format.</param>
+        /// <returns>A task representing the asynchronous operation for Adding Transaction data</returns>
         public async Task AddTransactionVoidData(string transactionId, string voidResponse)
         {
-            // Need to get details from vtexSettings
-            //VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+            // Retrieve VTEX settings
+            VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
 
-            //string vtexAppKey = vtexSettings.vtexAppKey;
-            string vtexAppKey = "vtexappkey-logixalpartnerus-YPIMAJ";
-            //string vtexAppToken = vtexSettings.vtexAppToken;
-            string vtexAppToken = "UHQUVUXMVJSNEWCBDCIWZCQCVLUGMPKEPWXWDDVHIWXPQNWUKKSZZLCODUVOFFPCMNYWYXSECVYRXUALEKJTWIXITZWIBJNYTQNAMPFAXVIHIFEPHHQJQBQOOUWPLYOO";
+            // Extract VTEX Key and Token credentials
+            string vtexAppKey = vtexSettings.vtexAppKey;
+            string vtexAppToken = vtexSettings.vtexAppToken;
 
+            // Validate credentials
+            if (string.IsNullOrWhiteSpace(vtexAppKey) || string.IsNullOrWhiteSpace(vtexAppToken))
+            {
+                _context.Vtex.Logger.Warn("AddTransactionVoidData", null, "VTEX App Key or Token is missing, aborting transaction update.");
+                return;
+            }
+
+            // Initialize VTEX Transaction API
             IVtexTransactionAPI vtexTransactionAPI = new VtexTransactionAPI(_httpContextAccessor, _httpClient, _context);
-            Console.WriteLine("------- AddTransactionVoidData : transactionId : " + transactionId + " , voidResponse : " + voidResponse);
+
+            // Add transaction data
             await vtexTransactionAPI.AddTransactionDataAsync(vtexAppKey, vtexAppToken, transactionId, voidResponse);
         }
 
-        
+        /// <summary>
+        /// Checks whether a partial void has been processed for a given transaction.
+        /// </summary>
+        /// <param name="transactionId">The unique identifier of the transaction.</param>
+        /// <returns>
+        /// A boolean indicating whether a partial void has been processed for the transaction.
+        /// Returns <c>true</c> if a void response exists; otherwise, returns <c>false</c>.
+        /// </returns>
         public async Task<bool> isPartialVoidDoneForTransaction(string transactionId)
         {
-            // Need to get details from enablePartialCancellation
-            AffirmVoidResponse affirmVoidResponse  = await _paymentRequestRepository.GetVoidResponseAsync(transactionId);
-
-            Console.WriteLine(" isPartialVoidDoneForTransaction:: affirmVoidResponse : " + JsonConvert.SerializeObject(affirmVoidResponse));
-
-            // Ensure it's properly converted to a boolean
-            if (affirmVoidResponse != null)
-            {
-                return true;
-            }
-            return false; // Default value if affirmVoidResponse is null
+            // Retrieve void response for the given transaction
+            AffirmVoidResponse affirmVoidResponse = await _paymentRequestRepository.GetVoidResponseAsync(transactionId);
+            // Log the response in structured format
+            _context.Vtex.Logger.Info(
+                "isPartialVoidDoneForTransaction",
+                null,
+                $"Transaction ID: {transactionId}, isPartialVoidDoneForTransaction: {affirmVoidResponse != null}"
+            );
+            return affirmVoidResponse != null;
         }
     }
 }

--- a/dotnet/Services/VtexTransactionService.cs
+++ b/dotnet/Services/VtexTransactionService.cs
@@ -118,5 +118,21 @@
             Console.WriteLine("------- AddTransactionVoidData : transactionId : " + transactionId + " , voidResponse : " + voidResponse);
             await vtexTransactionAPI.AddTransactionDataAsync(vtexAppKey, vtexAppToken, transactionId, voidResponse);
         }
+
+        
+        public async Task<bool> isPartialVoidDoneForTransaction(string transactionId)
+        {
+            // Need to get details from enablePartialCancellation
+            AffirmVoidResponse affirmVoidResponse  = await _paymentRequestRepository.GetVoidResponseAsync(transactionId);
+
+            Console.WriteLine(" isPartialVoidDoneForTransaction:: affirmVoidResponse : " + JsonConvert.SerializeObject(affirmVoidResponse));
+
+            // Ensure it's properly converted to a boolean
+            if (affirmVoidResponse != null)
+            {
+                return true;
+            }
+            return false; // Default value if affirmVoidResponse is null
+        }
     }
 }

--- a/dotnet/Services/VtexTransactionService.cs
+++ b/dotnet/Services/VtexTransactionService.cs
@@ -1,0 +1,122 @@
+﻿namespace Affirm.Services
+{
+    using Affirm.Data;
+    using Affirm.Models;
+    using Microsoft.AspNetCore.Http;
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Vtex.Api.Context;
+
+    public class VtexTransactionService : IVtexTransactionService
+    {
+        private readonly IPaymentRequestRepository _paymentRequestRepository;
+        private readonly HttpClient _httpClient;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IIOServiceContext _context;
+
+        public VtexTransactionService(IPaymentRequestRepository paymentRequestRepository, IHttpContextAccessor httpContextAccessor, HttpClient httpClient, IIOServiceContext context)
+        {
+            this._paymentRequestRepository = paymentRequestRepository ??
+                                            throw new ArgumentNullException(nameof(paymentRequestRepository));
+
+            this._httpContextAccessor = httpContextAccessor ??
+                                        throw new ArgumentNullException(nameof(httpContextAccessor));
+
+            this._httpClient = httpClient ??
+                               throw new ArgumentNullException(nameof(httpClient));
+
+            this._context = context ??
+                               throw new ArgumentNullException(nameof(context));
+        }
+
+        /// <summary>
+        /// Cancels a payment that was not yet approved or captured (settled).
+        /// </summary>
+        /// <param name="cancelPaymentRequest"></param>
+        /// <returns></returns>
+        public async Task<GetPaymentCancellationResponse> GetPaymentCancellations(string vtexAppKey, string vtexAppToken, string transactionId)
+        {
+            IVtexTransactionAPI vtexTransactionAPI = new VtexTransactionAPI(_httpContextAccessor, _httpClient, _context);
+            dynamic getPaymentCancellationsResponse = 
+                await vtexTransactionAPI.GetPaymentCancellationsAsync(vtexAppKey, vtexAppToken, transactionId);
+            GetPaymentCancellationResponse paymentCancellationResponse = null;
+            if (getPaymentCancellationsResponse != null)
+            {
+                Console.WriteLine("getPaymentCancellationsResponse : " + getPaymentCancellationsResponse);
+                _context.Vtex.Logger.Info("getPaymentCancellationsResponse : " + getPaymentCancellationsResponse);
+                // Convert dynamic response to JSON string
+                string jsonResponse = JsonConvert.SerializeObject(getPaymentCancellationsResponse);
+                // Deserialize JSON string into GetPaymentCancellationResponse object
+                paymentCancellationResponse = JsonConvert.DeserializeObject<GetPaymentCancellationResponse>(jsonResponse);
+            }
+            return paymentCancellationResponse;
+        }
+
+        /// <summary>
+        /// Gets the Partial Cancelled Item Amount on the transaction
+        /// </summary>
+        /// <param name="GetCancelledAmount"></param>
+        /// <returns></returns>
+        public async Task<int> GetPartialCancelledAmount(string transactionId)
+        {
+            // Need to get details from Katapult
+            VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+
+            //string vtexAppKey = vtexSettings.vtexAppKey;
+            //string vtexAppToken = vtexSettings.vtexAppToken;
+
+            //string vtexAppKey = vtexSettings.vtexAppKey;
+            string vtexAppKey = "vtexappkey-logixalpartnerus-YPIMAJ";
+            //string vtexAppToken = vtexSettings.vtexAppToken;
+            string vtexAppToken = "UHQUVUXMVJSNEWCBDCIWZCQCVLUGMPKEPWXWDDVHIWXPQNWUKKSZZLCODUVOFFPCMNYWYXSECVYRXUALEKJTWIXITZWIBJNYTQNAMPFAXVIHIFEPHHQJQBQOOUWPLYOO";
+
+            //Gets the Cancellations actions done on payment
+            var getPaymentCancellationsResponse = await GetPaymentCancellations(vtexAppKey, vtexAppToken, transactionId);
+
+            if (getPaymentCancellationsResponse == null || getPaymentCancellationsResponse?.actions == null)
+            {
+                return 0; // Return 0 if there are no actions
+            }
+            //Getting the sum of all the action value on Payment Cancellations Response
+            int cancelledAmount = getPaymentCancellationsResponse.actions.Sum(action => action.value);
+
+            Console.WriteLine("Cancelled Amount: " + cancelledAmount);
+
+            return cancelledAmount;
+        }
+
+        public async Task<bool> isPartialCancellationEnabled()
+        {
+            // Need to get details from enablePartialCancellation
+            VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+
+            Console.WriteLine("enablePartialCancellation : " + vtexSettings.enablePartialCancellation);
+
+            // Ensure it's properly converted to a boolean
+            if (bool.TryParse(vtexSettings.enablePartialCancellation.ToString(), out bool result))
+            {
+                return result;
+            }
+            return false; // Default value if conversion fails
+        }
+
+        public async Task AddTransactionVoidData(string transactionId, string voidResponse)
+        {
+            // Need to get details from vtexSettings
+            //VtexSettings vtexSettings = await _paymentRequestRepository.GetAppSettings();
+
+            //string vtexAppKey = vtexSettings.vtexAppKey;
+            string vtexAppKey = "vtexappkey-logixalpartnerus-YPIMAJ";
+            //string vtexAppToken = vtexSettings.vtexAppToken;
+            string vtexAppToken = "UHQUVUXMVJSNEWCBDCIWZCQCVLUGMPKEPWXWDDVHIWXPQNWUKKSZZLCODUVOFFPCMNYWYXSECVYRXUALEKJTWIXITZWIBJNYTQNAMPFAXVIHIFEPHHQJQBQOOUWPLYOO";
+
+            IVtexTransactionAPI vtexTransactionAPI = new VtexTransactionAPI(_httpContextAccessor, _httpClient, _context);
+            Console.WriteLine("------- AddTransactionVoidData : transactionId : " + transactionId + " , voidResponse : " + voidResponse);
+            await vtexTransactionAPI.AddTransactionDataAsync(vtexAppKey, vtexAppToken, transactionId, voidResponse);
+        }
+    }
+}

--- a/dotnet/StartupExtender.cs
+++ b/dotnet/StartupExtender.cs
@@ -23,6 +23,7 @@ namespace Vtex
             services.AddSingleton<IVtexEnvironmentVariableProvider, VtexEnvironmentVariableProvider>();
             services.AddTransient<IPaymentRequestRepository, PaymentRequestRepository>();
             services.AddTransient<IAffirmPaymentService, AffirmPaymentService>();
+            services.AddTransient<IVtexTransactionService, VtexTransactionService>();
         }
 
         public void ExtendConfigureBeforeRouting(IApplicationBuilder app, IWebHostEnvironment env)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "affirm-api",
-  "vendor": "vtex",
-  "version": "1.3.6",
+  "vendor": "logixalpartnerus",
+  "version": "1.3.14",
   "title": "Affirm",
-  "description": "An implementation of Affirm",
+  "description": "An implementation of Affirm By Logixal",
   "categories": [],
   "settingsSchema": {},
   "registries": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -83,6 +83,12 @@
     },
     {
       "name": "vbase-read-write"
+    },
+    {
+      "name": "ViewPayments"
+    },
+    {
+      "name": "MakePayments"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affirm-api",
   "vendor": "logixalpartnerus",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "title": "Affirm",
   "description": "An implementation of Affirm By Logixal",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "affirm-api",
-  "vendor": "logixalpartnerus",
-  "version": "1.3.21",
+  "vendor": "vtex",
+  "version": "1.3.6",
   "title": "Affirm",
-  "description": "An implementation of Affirm By Logixal",
+  "description": "An implementation of Affirm",
   "categories": [],
   "settingsSchema": {},
   "registries": [


### PR DESCRIPTION
## [Unreleased]

### Changed

 - Added Feature to Void the amount for partially cancelled items on order when capturing the final amount on Invoice
 - Managaned by feature flag enablePartialCancellation configure in Vtex Settings of Affirm Payment App
 - Added idempotency key for Refund and Void

Affirm Partial Cancellation Flow----

**Overview**

This PR introduces enhancements to the Affirm Partial Cancellation Flow in the VTEX Payment integration. The key updates ensure that when partial cancellations occur, the system correctly processes the voided amounts and updates the transaction details accordingly.

Flow Explanation

1. User places an order → VTEX calls the Affirm App Authorize API to authorize the amount for the transaction.

2. Admin cancels some items from the order.

3. Decision Point: Full Order Cancellation?

Yes → VTEX calls the VTEX Payment Cancel API to void the entire amount.

No → VTEX does not call the Affirm Payment Cancel API for partial cancellations.

4. Admin invoices the remaining items in the order.

5. VTEX calls the Affirm Payment Capture API to capture the amount for the remaining items.

6. Before capturing the amount, the Affirm Payment Capture API checks if enablePartialCancellation is enabled.

7. Decision Point: Is **enablePartialCancellation** enabled?

No → VTEX proceeds with capturing the remaining amount as usual.

Yes → Check if a partial void has already been done for this transaction.

8. Decision Point: **Is partial void already done**?

Yes → VTEX proceeds with capturing the remaining amount.

No → Fetch the total cancelled amount for the transaction.

9. Decision Point: Is **cancelledAmount > 0**?

No → VTEX proceeds with capturing the remaining amount.

Yes → Affirm Capture API calls the Affirm Void API to void the cancelled amount.

10. Affirm Void API saves the void response in the repository based on the transaction ID.

11. Decision Point: Is Void Response null?

Yes → The process stops, and no further action is taken.

No → Affirm Capture API updates VTEX Transaction Service, adding the Void Response to the transaction details.

![Affirm_Partial_Cancellation_Flow_Daigram_v1 0](https://github.com/user-attachments/assets/bbdaa47e-f21d-4aa6-80d4-72865fde31bf)

